### PR TITLE
 [proxima-core] #30 add proxy attributes to entities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ pom.xml.versionsBackup
 /messaging/server/nbproject/
 /smartbox/performance-test/target/
 *.iml
+*.log
 .idea
 server/log
 **/*_pb2.py

--- a/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/CassandraDBAccessorTest.java
+++ b/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/CassandraDBAccessorTest.java
@@ -24,6 +24,7 @@ import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.repository.AttributeDescriptor;
+import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.storage.Partition;
@@ -201,8 +202,8 @@ public class CassandraDBAccessorTest {
 
 
   Repository repo = Repository.Builder.ofTest(ConfigFactory.defaultApplication()).build();
-  AttributeDescriptor attr;
-  AttributeDescriptor attrWildcard;
+  AttributeDescriptorBase<?> attr;
+  AttributeDescriptorBase<?> attrWildcard;
   EntityDescriptor entity;
 
   public CassandraDBAccessorTest() throws URISyntaxException {

--- a/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/DefaultCQLFactoryTest.java
+++ b/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/DefaultCQLFactoryTest.java
@@ -22,6 +22,7 @@ import com.datastax.driver.core.Session;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.repository.AttributeDescriptor;
+import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.storage.StreamElement;
@@ -47,8 +48,8 @@ public class DefaultCQLFactoryTest {
 
   final Config cfg = ConfigFactory.defaultApplication();
   final Repository repo = Repository.Builder.ofTest(cfg).build();
-  final AttributeDescriptor attr;
-  final AttributeDescriptor attrWildcard;
+  final AttributeDescriptorBase<?> attr;
+  final AttributeDescriptorBase<?> attrWildcard;
   final EntityDescriptor entity;
   final PreparedStatement statement = mock(PreparedStatement.class);
   final Session session = mock(Session.class);

--- a/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/TransformingCQLFactoryTest.java
+++ b/cassandra/src/test/java/cz/o2/proxima/storage/cassandra/TransformingCQLFactoryTest.java
@@ -21,6 +21,7 @@ import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.Session;
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.repository.AttributeDescriptor;
+import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.storage.StreamElement;
@@ -44,7 +45,7 @@ import static org.mockito.Mockito.when;
 public class TransformingCQLFactoryTest {
 
   Repository repo = Repository.Builder.ofTest(ConfigFactory.defaultApplication()).build();
-  AttributeDescriptor attr;
+  AttributeDescriptorBase<?> attr;
   EntityDescriptor entity;
 
   final List<String> statements = new ArrayList<>();

--- a/core/src/main/java/cz/o2/proxima/repository/AttributeDescriptor.java
+++ b/core/src/main/java/cz/o2/proxima/repository/AttributeDescriptor.java
@@ -30,7 +30,6 @@ import cz.o2.proxima.scheme.ValueSerializer;
  */
 public interface AttributeDescriptor<T> extends Serializable {
 
-
   class Builder {
 
     private final Repository repo;
@@ -52,7 +51,7 @@ public interface AttributeDescriptor<T> extends Serializable {
     private URI schemeURI;
 
     @SuppressWarnings("unchecked")
-    public <T> AttributeDescriptor<T> build() {
+    public <T> AttributeDescriptorImpl<T> build() {
       Objects.requireNonNull(name, "Please specify name");
       Objects.requireNonNull(entity, "Please specify entity");
       Objects.requireNonNull(schemeURI, "Please specify scheme URI");
@@ -64,6 +63,14 @@ public interface AttributeDescriptor<T> extends Serializable {
 
   static Builder newBuilder(Repository repo) {
     return new Builder(repo);
+  }
+
+  static <T> AttributeDescriptorBase<T> newProxy(
+      String name,
+      AttributeDescriptorBase<T> target,
+      ProxyTransform transform) {
+
+    return new AttributeProxyDescriptorImpl<>(name, target, transform);
   }
 
   /** Retrieve name of the attribute. */
@@ -100,5 +107,11 @@ public interface AttributeDescriptor<T> extends Serializable {
    * Retrieve serializer for value type.
    */
   ValueSerializer<T> getValueSerializer();
+
+  /**
+   * Marker if this is a public attribute.
+   * @return {@code true} it this is public attribute
+   */
+  boolean isPublic();
 
 }

--- a/core/src/main/java/cz/o2/proxima/repository/AttributeDescriptorBase.java
+++ b/core/src/main/java/cz/o2/proxima/repository/AttributeDescriptorBase.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017 O2 Czech Republic, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.o2.proxima.repository;
+
+import cz.o2.proxima.scheme.ValueSerializer;
+import cz.o2.proxima.storage.OnlineAttributeWriter;
+import java.net.URI;
+import java.util.Objects;
+import lombok.Getter;
+import lombok.Setter;
+
+/**
+ * Base class for {@link AttributeDescriptorImpl} and {@link AttributeProxyDescriptorImpl}.
+ */
+public abstract class AttributeDescriptorBase<T> implements AttributeDescriptor<T> {
+
+  @Getter
+  protected final String entity;
+
+  @Getter
+  protected final String name;
+
+  @Getter
+  protected final URI schemeURI;
+
+  @Getter
+  protected final boolean proxy;
+
+  @Getter
+  protected final boolean wildcard;
+
+  @Getter
+  protected final ValueSerializer<T> valueSerializer;
+
+  @Getter
+  @Setter
+  protected OnlineAttributeWriter writer = null;
+
+  public AttributeDescriptorBase(
+      String name, String entity, URI schemeURI,
+      ValueSerializer<T> valueSerializer) {
+
+    this.name = Objects.requireNonNull(name);
+    this.entity = Objects.requireNonNull(entity);
+    this.schemeURI = Objects.requireNonNull(schemeURI);
+    this.wildcard = this.name.endsWith(".*");
+    this.proxy = false;
+    this.valueSerializer = Objects.requireNonNull(valueSerializer);
+    if (this.wildcard) {
+      if (name.length() < 3
+          || name.substring(0, name.length() - 1).contains("*")
+          || name.charAt(name.length() - 2) != '.') {
+
+        throw new IllegalArgumentException(
+            "Please specify wildcard attributes only in the format `<name>.*; for now. "
+                + "That is - wildcard attributes can contain only single asterisk "
+                + "right after a dot at the end of the attribute name. "
+                + "This is implementation constraint for now.");
+      }
+    }
+  }
+
+  public AttributeDescriptorBase(String name, AttributeDescriptorBase<T> target) {
+    this.name = Objects.requireNonNull(name);
+    this.entity = target.getEntity();
+    this.schemeURI = target.getSchemeURI();
+    this.proxy = true;
+    this.wildcard = target.isWildcard();
+    this.valueSerializer = target.getValueSerializer();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof AttributeDescriptor) {
+      AttributeDescriptor other = (AttributeDescriptor) obj;
+      return Objects.equals(other.getEntity(), entity) && Objects.equals(other.getName(), name);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(entity, name);
+  }
+
+  /**
+   * Retrieve name of the attribute if not wildcard, otherwise
+   * retrieve the prefix without the last asterisk.
+   */
+  @Override
+  public String toAttributePrefix(boolean includeLastDot) {
+    if (isWildcard()) {
+      return name.substring(0, name.length() - (includeLastDot ? 1 : 2));
+    }
+    return name;
+  }
+
+  @Override
+  public boolean isPublic() {
+    return !name.startsWith("_");
+  }
+
+}

--- a/core/src/main/java/cz/o2/proxima/repository/AttributeFamilyDescriptor.java
+++ b/core/src/main/java/cz/o2/proxima/repository/AttributeFamilyDescriptor.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
 /**
  * A family of attributes with the same storage.
  */
-public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
+public class AttributeFamilyDescriptor {
 
   public static final class Builder {
 
@@ -82,13 +82,13 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
 
     private Builder() { }
 
-    public Builder addAttribute(AttributeDescriptor desc) {
+    public Builder addAttribute(AttributeDescriptor<?> desc) {
       attributes.add(desc);
       return this;
     }
 
-    public AttributeFamilyDescriptor<AttributeWriterBase> build() {
-      return new AttributeFamilyDescriptor<>(
+    public AttributeFamilyDescriptor build() {
+      return new AttributeFamilyDescriptor(
           name, type, attributes, writer, commitLog, batchObservable,
           randomAccess, partitionedView, access, filter);
     }
@@ -119,7 +119,7 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    * Writer associated with this attribute family.
    */
   @Nullable
-  private final W writer;
+  private final AttributeWriterBase writer;
 
   @Nullable
   private final CommitLogReader commitLogReader;
@@ -133,10 +133,10 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
   @Nullable
   private final PartitionedView partitionedView;
 
-  private AttributeFamilyDescriptor(String name,
+  AttributeFamilyDescriptor(String name,
       StorageType type,
       List<AttributeDescriptor<?>> attributes,
-      @Nullable W writer,
+      @Nullable AttributeWriterBase writer,
       @Nullable CommitLogReader commitLogReader,
       @Nullable BatchLogObservable batchObservable,
       @Nullable RandomAccessReader randomAccess,
@@ -183,9 +183,10 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    * Retrieve writer for this family.
    * Empty if this family is not writable
    */
-  public Optional<W> getWriter() {
+  public Optional<AttributeWriterBase> getWriter() {
     if (!access.isReadonly()) {
-      return Optional.of(Objects.requireNonNull(writer));
+      return Optional.of(Objects.requireNonNull(
+          writer, "Family " + name + " is not readonly, but has no writer"));
     }
     return Optional.empty();
   }
@@ -196,7 +197,8 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    */
   public Optional<CommitLogReader> getCommitLogReader() {
     if (access.canReadCommitLog()) {
-      return Optional.of(Objects.requireNonNull(commitLogReader));
+      return Optional.of(Objects.requireNonNull(
+          commitLogReader, "Family " + name + " doesn't have commit-log reader"));
     }
     return Optional.empty();
   }
@@ -206,7 +208,8 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    */
   public Optional<BatchLogObservable> getBatchObservable() {
     if (access.canReadBatchSnapshot() || access.canReadBatchUpdates()) {
-      return Optional.of(Objects.requireNonNull(batchObservable));
+      return Optional.of(Objects.requireNonNull(
+          batchObservable, "Family " + name + " doesn't have batch observable"));
     }
     return Optional.empty();
   }
@@ -218,7 +221,8 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    */
   public Optional<RandomAccessReader> getRandomAccessReader() {
     if (access.canRandomRead()) {
-      return Optional.of(Objects.requireNonNull(randomAccess));
+      return Optional.of(Objects.requireNonNull(
+          randomAccess, "Family " + name + " doesn't have random access reader"));
     }
     return Optional.empty();
   }
@@ -229,7 +233,8 @@ public class AttributeFamilyDescriptor<W extends AttributeWriterBase> {
    */
   public Optional<PartitionedView> getPartitionedView() {
     if (access.canCreatePartitionedView()) {
-      return Optional.of(Objects.requireNonNull(partitionedView));
+      return Optional.of(Objects.requireNonNull(
+          partitionedView, "Family " + name + " doesn't have partitioned view"));
     }
     return Optional.empty();
   }

--- a/core/src/main/java/cz/o2/proxima/repository/AttributeFamilyProxyDescriptor.java
+++ b/core/src/main/java/cz/o2/proxima/repository/AttributeFamilyProxyDescriptor.java
@@ -1,0 +1,482 @@
+/**
+ * Copyright 2017 O2 Czech Republic, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.o2.proxima.repository;
+
+import cz.o2.proxima.storage.AccessType;
+import cz.o2.proxima.storage.AttributeWriterBase;
+import cz.o2.proxima.storage.CommitCallback;
+import cz.o2.proxima.storage.OnlineAttributeWriter;
+import cz.o2.proxima.storage.Partition;
+import cz.o2.proxima.storage.StorageType;
+import cz.o2.proxima.storage.StreamElement;
+import cz.o2.proxima.storage.batch.BatchLogObservable;
+import cz.o2.proxima.storage.batch.BatchLogObserver;
+import cz.o2.proxima.storage.commitlog.BulkLogObserver;
+import cz.o2.proxima.storage.commitlog.Cancellable;
+import cz.o2.proxima.storage.commitlog.CommitLogReader;
+import cz.o2.proxima.storage.commitlog.LogObserver;
+import cz.o2.proxima.storage.randomaccess.KeyValue;
+import cz.o2.proxima.storage.randomaccess.RandomAccessReader;
+import cz.o2.proxima.util.Pair;
+import cz.o2.proxima.view.PartitionedLogObserver;
+import cz.o2.proxima.view.PartitionedView;
+import cz.seznam.euphoria.core.client.dataset.Dataset;
+import cz.seznam.euphoria.core.client.flow.Flow;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+/**
+ * Proxy attribute family applying transformations of attributes
+ * to and from private space to public space.
+ */
+class AttributeFamilyProxyDescriptor extends AttributeFamilyDescriptor {
+
+  AttributeFamilyProxyDescriptor(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+    super(
+        "proxy::" + targetAttribute.getName() + "::" + targetFamily.getName(),
+        targetFamily.getType(),
+        Arrays.asList(targetAttribute), getWriter(targetAttribute, targetFamily),
+        getCommitLogReader(targetAttribute, targetFamily),
+        getBatchObservable(targetAttribute, targetFamily),
+        getRandomAccess(targetAttribute, targetFamily),
+        getPartitionedView(targetAttribute, targetFamily),
+        targetFamily.getType() == StorageType.PRIMARY
+            ? targetFamily.getAccess()
+            : AccessType.or(targetFamily.getAccess(), AccessType.from("read-only")),
+        targetFamily.getFilter());
+  }
+
+  private static OnlineAttributeWriter getWriter(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+
+    Optional<AttributeWriterBase> w = targetFamily.getWriter();
+    if (!w.isPresent() || !(w.get() instanceof OnlineAttributeWriter)) {
+      return null;
+    }
+    OnlineAttributeWriter writer = w.get().online();
+    return new OnlineAttributeWriter() {
+
+      @Override
+      public void rollback() {
+        writer.rollback();
+      }
+
+      @Override
+      public void write(StreamElement data, CommitCallback statusCallback) {
+        writer.write(
+            transformToRaw(data, targetAttribute),
+            statusCallback);
+      }
+
+      @Override
+      public URI getURI() {
+        return writer.getURI();
+      }
+
+    };
+  }
+
+  private static CommitLogReader getCommitLogReader(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+
+    Optional<CommitLogReader> target = targetFamily.getCommitLogReader();
+    if (!target.isPresent()) {
+      return null;
+    }
+    CommitLogReader reader = target.get();
+    return new CommitLogReader() {
+
+      @Override
+      public URI getURI() {
+        return reader.getURI();
+      }
+
+      @Override
+      public List<Partition> getPartitions() {
+        return reader.getPartitions();
+      }
+
+      @Override
+      public Cancellable observe(
+          String name,
+          CommitLogReader.Position position, LogObserver observer) {
+
+        return reader.observe(
+            name, position, wrapTransformed(targetAttribute, observer));
+      }
+
+      @Override
+      public Cancellable observePartitions(
+          Collection<Partition> partitions, CommitLogReader.Position position,
+          boolean stopAtCurrent, LogObserver observer) {
+
+        return reader.observePartitions(
+            partitions, position, stopAtCurrent,
+            wrapTransformed(targetAttribute, observer));
+      }
+
+      @Override
+      public Cancellable observeBulk(
+          String name, CommitLogReader.Position position,
+          BulkLogObserver observer) {
+
+        return reader.observeBulk(name, position, wrapTransformed(observer));
+      }
+
+      @Override
+      public void close() throws IOException {
+        reader.close();
+      }
+
+    };
+  }
+
+
+  private static BatchLogObservable getBatchObservable(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+
+    Optional<BatchLogObservable> target = targetFamily.getBatchObservable();
+    if (!target.isPresent()) {
+      return null;
+    }
+    BatchLogObservable reader = target.get();
+    return new BatchLogObservable() {
+
+      @Override
+      public List<Partition> getPartitions(long startStamp, long endStamp) {
+        return reader.getPartitions(startStamp, endStamp);
+      }
+
+      @Override
+      public void observe(
+          List<Partition> partitions,
+          List<AttributeDescriptor<?>> attributes,
+          BatchLogObserver observer) {
+
+        reader.observe(partitions, attributes, wrapTransformed(observer));
+      }
+
+    };
+  }
+
+  private static RandomAccessReader getRandomAccess(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+
+    Optional<RandomAccessReader> target = targetFamily.getRandomAccessReader();
+    if (!target.isPresent()) {
+      return null;
+    }
+    RandomAccessReader reader = target.get();
+    return new RandomAccessReader() {
+
+      @Override
+      public RandomAccessReader.Offset fetchOffset(
+          RandomAccessReader.Listing type, String key) {
+
+        if (type == Listing.ATTRIBUTE) {
+          return reader.fetchOffset(
+              type, targetAttribute.getTransform().fromProxy(key));
+        }
+        return reader.fetchOffset(type, key);
+      }
+
+      @Override
+      public Optional<KeyValue<?>> get(
+          String key, String attribute, AttributeDescriptor<?> desc) {
+
+        ProxyTransform transform = targetAttribute.getTransform();
+        return reader.get(key, transform.fromProxy(attribute), desc)
+            .map(kv -> transformToProxy(kv, targetAttribute));
+      }
+
+      @Override
+      public void scanWildcard(
+          String key, AttributeDescriptor<?> wildcard,
+          RandomAccessReader.Offset offset, int limit, Consumer<KeyValue<?>> consumer) {
+
+        if (!targetAttribute.isWildcard()) {
+          throw new IllegalArgumentException(
+              "Proxy target is not wildcard attribute!");
+        }
+        reader.scanWildcard(key, targetAttribute.getTarget(), offset, limit, kv -> {
+          consumer.accept(transformToProxy(kv, targetAttribute));
+        });
+      }
+
+      @Override
+      public void listEntities(
+          RandomAccessReader.Offset offset, int limit,
+          Consumer<Pair<RandomAccessReader.Offset, String>> consumer) {
+
+      }
+
+      @Override
+      public void close() throws IOException {
+      }
+
+    };
+  }
+
+  private static PartitionedView getPartitionedView(
+      AttributeProxyDescriptorImpl<?> targetAttribute,
+      AttributeFamilyDescriptor targetFamily) {
+
+    Optional<PartitionedView> target = targetFamily.getPartitionedView();
+    if (!target.isPresent()) {
+      return null;
+    }
+    PartitionedView view = target.get();
+    return new PartitionedView() {
+
+      @Override
+      public List<Partition> getPartitions() {
+        return view.getPartitions();
+      }
+
+      @Override
+      public <T> Dataset<T> observePartitions(
+          Flow flow,
+          Collection<Partition> partitions,
+          PartitionedLogObserver<T> observer) {
+
+        return view.observePartitions(flow, partitions, wrapTransformed(
+            targetAttribute, observer));
+      }
+
+      @Override
+      public <T> Dataset<T> observe(
+          Flow flow, String name, PartitionedLogObserver<T> observer) {
+
+        return view.observe(flow, name, wrapTransformed(
+            targetAttribute, observer));
+      }
+
+    };
+  }
+
+  private static LogObserver wrapTransformed(
+      AttributeProxyDescriptorImpl<?> proxy,
+      LogObserver observer) {
+
+    return new LogObserver() {
+
+      @Override
+      public boolean onNext(StreamElement ingest, LogObserver.ConfirmCallback confirm) {
+        return observer.onNext(
+            transformToProxy(ingest, proxy), confirm);
+      }
+
+      @Override
+      public boolean onNext(
+          StreamElement ingest,
+          Partition partition,
+          LogObserver.ConfirmCallback confirm) {
+
+        return observer.onNext(
+            transformToProxy(ingest, proxy),
+            partition, confirm);
+      }
+
+      @Override
+      public void onCompleted() {
+        observer.onCompleted();
+      }
+
+      @Override
+      public void onCancelled() {
+        observer.onCancelled();
+      }
+
+      @Override
+      public void onError(Throwable error) {
+        observer.onError(error);
+      }
+
+      @Override
+      public void close() throws Exception {
+        observer.close();
+      }
+
+    };
+  }
+
+  static BulkLogObserver wrapTransformed(BulkLogObserver observer) {
+    return new BulkLogObserver() {
+
+      @Override
+      public void onCompleted() {
+        observer.onCompleted();
+      }
+
+      @Override
+      public void onError(Throwable error) {
+        observer.onError(error);
+      }
+
+      @Override
+      public boolean onNext(
+          StreamElement ingest,
+          Partition partition,
+          BulkLogObserver.BulkCommitter confirm) {
+
+        return observer.onNext(ingest, partition, confirm);
+      }
+
+      @Override
+      public void onRestart() {
+        observer.onRestart();
+      }
+
+      @Override
+      public void onCancelled() {
+        observer.onCancelled();
+      }
+
+      @Override
+      public void close() throws Exception {
+        observer.close();
+      }
+
+    };
+  }
+
+
+  static BatchLogObserver wrapTransformed(BatchLogObserver observer) {
+    return new BatchLogObserver() {
+
+      @Override
+      public boolean onNext(
+          StreamElement ingest,
+          Partition partition) {
+
+        return observer.onNext(ingest, partition);
+      }
+
+      @Override
+      public void onCompleted() {
+        observer.onCompleted();
+      }
+
+      @Override
+      public void onError(Throwable error) {
+        observer.onError(error);
+      }
+
+    };
+  }
+
+
+  private static <T> PartitionedLogObserver<T> wrapTransformed(
+      AttributeProxyDescriptorImpl<?> target, PartitionedLogObserver<T> observer) {
+
+    return new PartitionedLogObserver<T>() {
+
+      @Override
+      public void onRepartition(Collection<Partition> assigned) {
+        observer.onRepartition(assigned);
+      }
+
+      @Override
+      public boolean onNext(
+          StreamElement ingest,
+          PartitionedLogObserver.ConfirmCallback confirm,
+          Partition partition,
+          PartitionedLogObserver.Consumer<T> collector) {
+
+        return observer.onNext(transformToProxy(ingest, target),
+            confirm, partition, collector);
+      }
+
+      @Override
+      public void onCompleted() {
+        observer.onCompleted();
+      }
+
+      @Override
+      public void onError(Throwable error) {
+        observer.onError(error);
+      }
+
+    };
+  }
+
+  private static StreamElement transformToRaw(
+      StreamElement data,
+      AttributeProxyDescriptorImpl<?> targetDesc) {
+
+    return transform(data,
+        targetDesc.getTarget(),
+        targetDesc.getTransform()::fromProxy);
+  }
+
+  private static StreamElement transformToProxy(
+      StreamElement data,
+      AttributeProxyDescriptorImpl<?> targetDesc) {
+
+    return transform(data, targetDesc, targetDesc.getTransform()::toProxy);
+  }
+
+  private static KeyValue<?> transformToProxy(
+      KeyValue<?> kv,
+      AttributeProxyDescriptorImpl<?> targetDesc) {
+
+    return KeyValue.of(
+        kv.getEntityDescriptor(),
+        targetDesc, kv.getKey(),
+        targetDesc.getTransform().toProxy(kv.getAttribute()),
+        kv.getOffset(), kv.getValueBytes());
+  }
+
+  private static StreamElement transform(
+      StreamElement data,
+      AttributeDescriptor<?> target,
+      Function<String, String> transform) {
+
+    if (data.isDelete()) {
+      if (data.isDeleteWildcard()) {
+        return StreamElement.deleteWildcard(
+            data.getEntityDescriptor(),
+            target, data.getUuid(), data.getKey(), data.getStamp());
+      } else {
+        return StreamElement.delete(
+            data.getEntityDescriptor(), target,
+            data.getUuid(), data.getKey(),
+            transform.apply(data.getAttribute()),
+            data.getStamp());
+      }
+    }
+    return StreamElement.update(data.getEntityDescriptor(),
+        target, data.getUuid(), data.getKey(),
+        transform.apply(data.getAttribute()),
+        data.getStamp(), data.getValue());
+  }
+
+
+
+
+}

--- a/core/src/main/java/cz/o2/proxima/repository/AttributeProxyDescriptorImpl.java
+++ b/core/src/main/java/cz/o2/proxima/repository/AttributeProxyDescriptorImpl.java
@@ -13,30 +13,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package cz.o2.proxima.repository;
 
-import java.net.URI;
-import cz.o2.proxima.scheme.ValueSerializer;
+import lombok.Getter;
 
 /**
- * Descriptor of attribute of entity.
+ * Proxy to another attribute.
  */
-public class AttributeDescriptorImpl<T>
+class AttributeProxyDescriptorImpl<T>
     extends AttributeDescriptorBase<T> {
 
-  AttributeDescriptorImpl(
-      String name, String entity,
-      URI schemeURI, ValueSerializer<T> serializer) {
+  @Getter
+  private final AttributeDescriptorBase<T> target;
 
-    super(name, entity, schemeURI, serializer);
+  @Getter
+  private final ProxyTransform transform;
+
+  AttributeProxyDescriptorImpl(
+      String name,
+      AttributeDescriptorBase<T> target,
+      ProxyTransform transform) {
+
+    super(name, target);
+    this.target = target;
+    this.transform = transform;
   }
-
 
   @Override
   public String toString() {
-    return "AttributeDescriptor(entity=" + entity + ", name=" + name + ")";
+    return "AttributeProxyDescriptorImpl("
+        + "target=" + target
+        + ", name=" + name
+        + ")";
   }
-
 
 }

--- a/core/src/main/java/cz/o2/proxima/repository/EntityDescriptor.java
+++ b/core/src/main/java/cz/o2/proxima/repository/EntityDescriptor.java
@@ -36,9 +36,9 @@ public interface EntityDescriptor extends Serializable {
     @Accessors(chain = true)
     private String name;
 
-    List<AttributeDescriptor> attributes = new ArrayList<>();
+    private final List<AttributeDescriptorBase<?>> attributes = new ArrayList<>();
 
-    public Builder addAttribute(AttributeDescriptor attr) {
+    public Builder addAttribute(AttributeDescriptorBase<?> attr) {
       attributes.add(attr);
       return this;
     }
@@ -46,6 +46,14 @@ public interface EntityDescriptor extends Serializable {
     public EntityDescriptor build() {
       return new EntityDescriptorImpl(name, Collections.unmodifiableList(attributes));
     }
+
+    AttributeDescriptorBase<?> findAttribute(String attr) {
+      return attributes.stream().filter(a -> a.getName()
+          .equals(attr)).findAny()
+          .orElseThrow(() -> new IllegalArgumentException(
+              "Cannot find attribute " + attr + " of entity " + this.name));
+    }
+
   }
 
   static Builder newBuilder() {
@@ -56,10 +64,37 @@ public interface EntityDescriptor extends Serializable {
   /** Name of the entity. */
   String getName();
 
-  /** Find attribute based by name. */
-  Optional<AttributeDescriptor<?>> findAttribute(String name);
+  /**
+   * Find attribute by name.
+   * @param name name of the attribute to search for
+   * @param includeProtected {@code true} to allow search for protected fields (prefixed by _).
+   * @return optional found attribute descriptor
+   */
+  Optional<AttributeDescriptor<?>> findAttribute(String name, boolean includeProtected);
 
-  /** List all attribute descriptors of given entity. */
-  List<AttributeDescriptor> getAllAttributes();
+  /**
+   * Find attribute by name.
+   * Do not search protected fields (prefixed by _).
+   * @param name name of the attribute to search for
+   * @return optional found attribute descriptor
+   */
+  default Optional<AttributeDescriptor<?>> findAttribute(String name) {
+    return findAttribute(name, false);
+  }
+
+  /**
+   * Find all attributes of this entity.
+   * @param includeProtected when {@code true} then protected attributes are
+   * also included (prefixed by _).
+   * @return
+   */
+  List<AttributeDescriptor<?>> getAllAttributes(boolean includeProtected);
+
+  /**
+   * List all attribute descriptors of given entity.
+   */
+  default List<AttributeDescriptor<?>> getAllAttributes() {
+    return getAllAttributes(false);
+  }
 
 }

--- a/core/src/main/java/cz/o2/proxima/repository/ProxyTransform.java
+++ b/core/src/main/java/cz/o2/proxima/repository/ProxyTransform.java
@@ -13,30 +13,27 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package cz.o2.proxima.repository;
 
-import java.net.URI;
-import cz.o2.proxima.scheme.ValueSerializer;
+import java.io.Serializable;
 
 /**
- * Descriptor of attribute of entity.
+ * A transformation of attribute name applied both on reading and writing attribute.
  */
-public class AttributeDescriptorImpl<T>
-    extends AttributeDescriptorBase<T> {
+public interface ProxyTransform extends Serializable {
 
-  AttributeDescriptorImpl(
-      String name, String entity,
-      URI schemeURI, ValueSerializer<T> serializer) {
+  /**
+   * Apply transformation to attribute name from proxy naming.
+   * @param proxy name of the attribute in proxy namespace
+   * @return the raw attribute
+   */
+  String fromProxy(String proxy);
 
-    super(name, entity, schemeURI, serializer);
-  }
-
-
-  @Override
-  public String toString() {
-    return "AttributeDescriptor(entity=" + entity + ", name=" + name + ")";
-  }
-
+  /**
+   * Apply transformation to attribute name to proxy naming.
+   * @param raw the raw attribute name
+   * @return the proxy attribute name
+   */
+  String toProxy(String raw);
 
 }

--- a/core/src/main/java/cz/o2/proxima/storage/AccessType.java
+++ b/core/src/main/java/cz/o2/proxima/storage/AccessType.java
@@ -115,6 +115,56 @@ public interface AccessType {
 
   }
 
+  static AccessType or(AccessType left, AccessType right) {
+    return new AccessType() {
+      @Override
+      public boolean canReadBatchUpdates() {
+        return left.canReadBatchUpdates() || right.canReadBatchUpdates();
+      }
+
+      @Override
+      public boolean canReadBatchSnapshot() {
+        return left.canReadBatchSnapshot() || right.canReadBatchSnapshot();
+      }
+
+      @Override
+      public boolean canRandomRead() {
+        return left.canRandomRead() || right.canRandomRead();
+      }
+
+      @Override
+      public boolean canReadCommitLog() {
+        return left.canReadCommitLog() || right.canReadCommitLog();
+      }
+
+      @Override
+      public boolean isStateCommitLog() {
+        return left.isStateCommitLog() || right.isStateCommitLog();
+      }
+
+      @Override
+      public boolean isReadonly() {
+        return left.isReadonly() || right.isReadonly();
+      }
+
+      @Override
+      public boolean isListPrimaryKey() {
+        return left.isListPrimaryKey() || right.isListPrimaryKey();
+      }
+
+      @Override
+      public boolean isWriteOnly() {
+        return left.isWriteOnly() || right.isWriteOnly();
+      }
+
+      @Override
+      public boolean canCreatePartitionedView() {
+        return left.canCreatePartitionedView() || right.canCreatePartitionedView();
+      }
+
+    };
+  }
+
   /**
    * @return {@code true} if this family can be used to access data by batch
    * observing of updates.

--- a/core/src/test/java/cz/o2/proxima/repository/PartitionedViewTest.java
+++ b/core/src/test/java/cz/o2/proxima/repository/PartitionedViewTest.java
@@ -52,7 +52,7 @@ public class PartitionedViewTest implements Serializable {
   @Before
   public void setUp() {
     executor = new InMemExecutor();
-    AttributeFamilyDescriptor<? extends AttributeWriterBase> family = repo.getAllFamilies()
+    AttributeFamilyDescriptor family = repo.getAllFamilies()
         .filter(af -> af.getName().equals("event-storage-stream"))
         .findAny()
         .get();

--- a/core/src/test/java/cz/o2/proxima/transform/EventTransform.java
+++ b/core/src/test/java/cz/o2/proxima/transform/EventTransform.java
@@ -13,30 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package cz.o2.proxima.transform;
 
-package cz.o2.proxima.repository;
-
-import java.net.URI;
-import cz.o2.proxima.scheme.ValueSerializer;
+import cz.o2.proxima.repository.ProxyTransform;
 
 /**
- * Descriptor of attribute of entity.
+ * Transformation from proxy space (event.*) to raw space (_e.*).
  */
-public class AttributeDescriptorImpl<T>
-    extends AttributeDescriptorBase<T> {
-
-  AttributeDescriptorImpl(
-      String name, String entity,
-      URI schemeURI, ValueSerializer<T> serializer) {
-
-    super(name, entity, schemeURI, serializer);
-  }
-
+public class EventTransform implements ProxyTransform {
 
   @Override
-  public String toString() {
-    return "AttributeDescriptor(entity=" + entity + ", name=" + name + ")";
+  public String fromProxy(String proxy) {
+    int pos = proxy.indexOf('.');
+    return "_e." + proxy.substring(pos + 1);
   }
 
+  @Override
+  public String toProxy(String raw) {
+    int pos = raw.indexOf('.');
+    return "event." + raw.substring(pos + 1);
+  }
 
 }

--- a/core/src/test/resources/reference.conf
+++ b/core/src/test/resources/reference.conf
@@ -10,16 +10,16 @@
     # this entity represents state of the gateway
     gateway: {
       attributes: {
-        armed: { scheme: "bytes" }
-        users: { scheme: "bytes" }
-        status: { scheme: "bytes" }
+        armed: { scheme: bytes }
+        users: { scheme: bytes }
+        status: { scheme: bytes }
 
         # the following defines a pattern for attributes
         # each attribute that matches the pattern is treated the same
-        "device.*": { scheme: "bytes" }
+        "device.*": { scheme: bytes }
 
         # settings for specific rule
-        "rule.*": { scheme: "bytes" }
+        "rule.*": { scheme: bytes }
 
         # this is fake attribute that always fails validation
         fail: { scheme: "fail:whenever" }
@@ -31,8 +31,23 @@
     dummy: {
       attributes: {
         data: { scheme: bytes }
-        "wildcard.*": { scheme: "bytes" }
+        "wildcard.*": { scheme: "bytes" }        
       }
+    }
+
+    proxied {
+
+      attributes {
+        # this is "protected" field and should not be accessed directly
+        "_e.*": { scheme: bytes }
+
+        # this is proxy public attribute performing transformation
+        "event.*": {
+          proxy: "_e.*"
+          apply: cz.o2.proxima.transform.EventTransform
+        }
+      }
+
     }
 
   }
@@ -71,6 +86,14 @@
       entity: dummy
       attributes: [ "*" ]
       storage: "inmem:///proxima/dummy"
+      type: primary
+      access: "commit-log, random-access"
+    }
+
+    proxy-primary {
+      entity: proxied
+      attributes: [ "_e.*" ]
+      storage: "inmem:///proxima/proxy"
       type: primary
       access: "commit-log, random-access"
     }

--- a/kafka/src/test/java/cz/o2/proxima/storage/kafka/LocalKafkaCommitLogDescriptorTest.java
+++ b/kafka/src/test/java/cz/o2/proxima/storage/kafka/LocalKafkaCommitLogDescriptorTest.java
@@ -18,6 +18,7 @@ package cz.o2.proxima.storage.kafka;
 
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.repository.AttributeDescriptor;
+import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.storage.Partition;
@@ -45,7 +46,7 @@ import org.junit.Test;
 public class LocalKafkaCommitLogDescriptorTest {
 
   final Repository repo = Repository.Builder.ofTest(ConfigFactory.empty()).build();
-  final AttributeDescriptor attr;
+  final AttributeDescriptorBase<?> attr;
   final EntityDescriptor entity;
   final URI storageURI;
 

--- a/maven/src/main/resources/java-source.ftlh
+++ b/maven/src/main/resources/java-source.ftlh
@@ -97,9 +97,9 @@ public class ${java_classname} {
   </#list> <#-- entity.attributes as attribute -->
 
     public Optional<CommitLogReader> getCommitLog(AttributeDescriptor<?>... attributes) {
-      Set<AttributeFamilyDescriptor<?>> descriptors = new HashSet<>();
+      Set<AttributeFamilyDescriptor> descriptors = new HashSet<>();
       for (AttributeDescriptor<?> attr : attributes) {
-        Set<AttributeFamilyDescriptor<?>> commitLogs = repo.getFamiliesForAttribute(attr)
+        Set<AttributeFamilyDescriptor> commitLogs = repo.getFamiliesForAttribute(attr)
             .stream()
             .filter(af -> af.getCommitLogReader().isPresent())
             .collect(Collectors.toSet());
@@ -118,9 +118,9 @@ public class ${java_classname} {
 
     public Optional<PartitionedView> getPartitionedView(AttributeDescriptor<?>... attributes) {
 
-      Set<AttributeFamilyDescriptor<?>> descriptors = new HashSet<>();
+      Set<AttributeFamilyDescriptor> descriptors = new HashSet<>();
       for (AttributeDescriptor<?> attr : attributes) {
-        Set<AttributeFamilyDescriptor<?>> views = repo.getFamiliesForAttribute(attr)
+        Set<AttributeFamilyDescriptor> views = repo.getFamiliesForAttribute(attr)
             .stream()
             .filter(af -> af.getAccess().canCreatePartitionedView())
             .collect(Collectors.toSet());

--- a/server/src/main/java/cz/o2/proxima/server/IngestServer.java
+++ b/server/src/main/java/cz/o2/proxima/server/IngestServer.java
@@ -651,14 +651,13 @@ public class IngestServer {
   protected void startConsumerThreads() throws InterruptedException {
 
     // index the repository
-    Map<AttributeFamilyDescriptor<?>, Set<AttributeFamilyDescriptor<?>>> familyToCommitLog;
+    Map<AttributeFamilyDescriptor, Set<AttributeFamilyDescriptor>> familyToCommitLog;
     familyToCommitLog = indexFamilyToCommitLogs();
 
     LOG.info("Starting consumer threads for familyToCommitLog {}", familyToCommitLog);
     // execute threads to consume the commit log
-    familyToCommitLog.entrySet().stream().forEach(entry -> {
-      AttributeFamilyDescriptor<?> family = entry.getKey();
-      for (AttributeFamilyDescriptor<?> commitLogFamily : entry.getValue()) {
+    familyToCommitLog.forEach((family, logs) -> {
+      for (AttributeFamilyDescriptor commitLogFamily : logs) {
         CommitLogReader commitLog = commitLogFamily.getCommitLogReader()
             .orElseThrow(() -> new IllegalStateException(
                 "Failed validation on consistency of attribute families. Fix code!"));
@@ -689,7 +688,7 @@ public class IngestServer {
   }
 
   private void runTransformer(String name, TransformationDescriptor transform) {
-    AttributeFamilyDescriptor<?> family = transform.getAttributes()
+    AttributeFamilyDescriptor family = transform.getAttributes()
         .stream()
         .map(a -> this.repo.getFamiliesForAttribute(a)
             .stream().filter(af -> af.getAccess().canReadCommitLog())
@@ -768,7 +767,7 @@ public class IngestServer {
    * themselves.
    */
   @SuppressWarnings("unchecked")
-  private Map<AttributeFamilyDescriptor<?>, Set<AttributeFamilyDescriptor<?>>>
+  private Map<AttributeFamilyDescriptor, Set<AttributeFamilyDescriptor>>
   indexFamilyToCommitLogs() {
 
     // each attribute and its associated primary family

--- a/server/src/test/java/cz/o2/proxima/server/IngestServiceTest.java
+++ b/server/src/test/java/cz/o2/proxima/server/IngestServiceTest.java
@@ -20,7 +20,6 @@ import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.proto.service.Rpc;
-import cz.o2.proxima.server.IngestServer;
 import cz.o2.proxima.server.test.Test.ExtendedMessage;
 import cz.o2.proxima.storage.InMemBulkStorage;
 import cz.o2.proxima.storage.InMemStorage;

--- a/tools/src/main/java/cz/o2/proxima/tools/groovy/Console.java
+++ b/tools/src/main/java/cz/o2/proxima/tools/groovy/Console.java
@@ -29,7 +29,6 @@ import cz.o2.proxima.repository.AttributeDescriptor;
 import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
-import cz.o2.proxima.storage.AttributeWriterBase;
 import cz.o2.proxima.storage.OnlineAttributeWriter;
 import cz.o2.proxima.storage.StorageType;
 import cz.o2.proxima.storage.StreamElement;
@@ -127,11 +126,6 @@ public class Console {
     return GroovyEnv.of(conf,
         (GroovyClassLoader) Thread.currentThread().getContextClassLoader(),
         repo);
-  }
-
-  private static void usage() {
-    System.err.println(String.format("Usage %s <config> [<config>]", Console.class.getName()));
-    System.exit(1);
   }
 
   private Repository getRepo(String[] paths) {
@@ -234,7 +228,7 @@ public class Console {
 
     DatasetBuilder<TypedIngest<Object>> builder = () -> {
       final Dataset<TypedIngest<Object>> input;
-      AttributeFamilyDescriptor<? extends AttributeWriterBase> family = repo.getFamiliesForAttribute(attrDesc)
+      AttributeFamilyDescriptor family = repo.getFamiliesForAttribute(attrDesc)
           .stream()
           .filter(af -> af.getAccess().canReadBatchSnapshot())
           .filter(af -> af.getBatchObservable().isPresent())
@@ -315,7 +309,7 @@ public class Console {
       long startStamp,
       long endStamp) {
 
-    AttributeFamilyDescriptor<? extends AttributeWriterBase> family = repo.getFamiliesForAttribute(attrDesc)
+    AttributeFamilyDescriptor family = repo.getFamiliesForAttribute(attrDesc)
         .stream()
         .filter(af -> af.getAccess().canReadBatchUpdates())
         .filter(af -> af.getBatchObservable().isPresent())
@@ -382,7 +376,7 @@ public class Console {
         TextFormat.merge(textFormat, builder);
         payload = builder.build().toByteArray();
       }
-      Set<AttributeFamilyDescriptor<?>> families = repo.getFamiliesForAttribute(attrDesc);
+      Set<AttributeFamilyDescriptor> families = repo.getFamiliesForAttribute(attrDesc);
       OnlineAttributeWriter writer = families.stream()
           .filter(af -> af.getType() == StorageType.PRIMARY)
           .findAny()
@@ -416,7 +410,7 @@ public class Console {
       EntityDescriptor entityDesc, AttributeDescriptor<?> attrDesc,
       String key, String attribute) throws InterruptedException {
 
-      Set<AttributeFamilyDescriptor<?>> families = repo.getFamiliesForAttribute(attrDesc);
+      Set<AttributeFamilyDescriptor> families = repo.getFamiliesForAttribute(attrDesc);
       OnlineAttributeWriter writer = families.stream()
           .filter(af -> af.getType() == StorageType.PRIMARY)
           .findAny()

--- a/tools/src/main/java/cz/o2/proxima/tools/io/BatchSource.java
+++ b/tools/src/main/java/cz/o2/proxima/tools/io/BatchSource.java
@@ -46,7 +46,7 @@ public class BatchSource<T> implements DataSource<TypedIngest<T>> {
 
   public static <T> BatchSource<T> of(
       BatchLogObservable observable,
-      AttributeFamilyDescriptor<?> family,
+      AttributeFamilyDescriptor family,
       long startStamp,
       long endStamp) {
 

--- a/tools/src/main/java/cz/o2/proxima/tools/io/ConsoleRandomReader.java
+++ b/tools/src/main/java/cz/o2/proxima/tools/io/ConsoleRandomReader.java
@@ -53,11 +53,10 @@ public class ConsoleRandomReader implements Closeable {
     this.listEntityOffsets = new HashMap<>();
 
     desc.getAllAttributes().forEach(f -> {
-      Optional<AttributeFamilyDescriptor<?>> randomFamily;
+      Optional<AttributeFamilyDescriptor> randomFamily;
       randomFamily = repo.getFamiliesForAttribute(f)
           .stream()
-          .filter(af -> af.getAccess().isListPrimaryKey()
-              && af.getAccess().canRandomRead())
+          .filter(af -> af.getAccess().canRandomRead())
           .findAny();
       if (randomFamily.isPresent()) {
         attrToReader.put(f, randomFamily.get().getRandomAccessReader().get());


### PR DESCRIPTION
This is a draft of introducing virtual proxy attributes to entities. The proxy attribute is not physically existing in storage and is built up when accessing it (read, write, delete). For now, this functionality is very limited, but unfortunately that's all what I need now.