### PR TITLE
Remove redundant test-jar declaration

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -62,19 +62,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 


### PR DESCRIPTION
Test jar is being build anyway and this section cause problem with releases du to duplicate deploy of the same jar