### PR TITLE
Fixed resource leak in tests and shading guava

### DIFF
--- a/direct/io-gcloud-storage/pom.xml
+++ b/direct/io-gcloud-storage/pom.xml
@@ -228,6 +228,13 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>${guava.version}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>

--- a/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/BulkGCloudStorageWriter.java
+++ b/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/BulkGCloudStorageWriter.java
@@ -142,7 +142,8 @@ public class BulkGCloudStorageWriter
     tmpDir = Optional.ofNullable(cfg.get("tmp.dir"))
         .map(Object::toString)
         .map(File::new)
-        .orElse(new File("/tmp/bulk-cloud-storage-" + UUID.randomUUID()));
+        .orElse(new File(System.getProperty("java.io.tmpdir") + File.pathSeparator
+            + "bulk-cloud-storage-" + UUID.randomUUID()));
 
     rollPeriod = Optional.ofNullable(cfg.get("log-roll-interval"))
         .map(Object::toString)

--- a/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/BulkGCloudStorageWriterTest.java
+++ b/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/BulkGCloudStorageWriterTest.java
@@ -18,7 +18,7 @@ package cz.o2.proxima.direct.gcloud.storage;
 import com.google.cloud.storage.Blob;
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.direct.core.DirectDataOperator;
-import cz.o2.proxima.internal.shaded.com.google.common.collect.Iterables;
+import com.google.common.collect.Iterables;
 import cz.o2.proxima.repository.AttributeDescriptor;
 import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
@@ -42,8 +42,11 @@ import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import static org.junit.Assert.*;
+
+import org.junit.rules.TemporaryFolder;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import static org.mockito.Mockito.*;
@@ -53,6 +56,7 @@ import static org.mockito.Mockito.*;
  */
 @RunWith(Parameterized.class)
 public class BulkGCloudStorageWriterTest {
+  @Rule public final TemporaryFolder tempFolder = new TemporaryFolder();
 
   final Repository repo = Repository.of(ConfigFactory.load().resolve());
   final DirectDataOperator direct = repo.asDataOperator(DirectDataOperator.class);
@@ -93,7 +97,7 @@ public class BulkGCloudStorageWriterTest {
   }
 
   @Before
-  public void setUp() throws URISyntaxException {
+  public void setUp() throws URISyntaxException, IOException {
     blobs = Collections.synchronizedNavigableSet(new TreeSet<>());
     onFlushToBlob.set(null);
     written = Collections.synchronizedMap(new HashMap<>());
@@ -308,11 +312,12 @@ public class BulkGCloudStorageWriterTest {
     }
   }
 
-  private Map<String, Object> cfg() {
+  private Map<String, Object> cfg() throws IOException {
     Map<String, Object> ret = new HashMap<>();
     ret.put("log-roll-interval", "1000");
     ret.put("allowed-lateness-ms", 500);
     ret.put("flush-delay-ms", 50);
+    ret.put("tmp.dir", tempFolder.newFolder().getAbsolutePath());
     if (gzip) {
       ret.put("gzip", "true");
     }


### PR DESCRIPTION
Tests leave a lot of folders like /tmp/bulk-cloud-storage-3cf95540-cad5-420a-8799-effde9e3bd5a

I'm not sure about that shading change, please check it.