### PR TITLE
Allow update pubsub.subscription.ack-deadline in io-pubsub

### DIFF
--- a/direct/io-pubsub/README.md
+++ b/direct/io-pubsub/README.md
@@ -1,0 +1,44 @@
+# Proxima IO-pubsub
+Another implementation of proxima `commit-log` access pattern using Google PubSub.
+
+## PubSub limitations:
+- unable to seek in commit log
+- unable to stopAtCurrent offset
+
+## Basic usage example:
+```
+attributeFamilies {
+    my-commit-log {
+        entity: "entity",
+        attributes: ["attribute1", "attribute2"]
+        storage: "gps://"${gcloud.projectId}"/my-commitlog"
+        type: "primary"
+        access: "commit-log"
+    }
+}
+```
+
+## Configuration options:
+- pubsub.subscription.auto-create = `boolean` (DEFAULT: `true`) - enable/disable subscription auto create.
+- pubsub.subscription.ack-deadline = `integer` (DEFAULT: `600`) - max subscription ack deadline in seconds (check PubSub documentation for details).
+- pubsub.deadline-max-ms = `integer` (DEFAULT: `60000`) - max consumer ack deadline in ms.
+
+## Full example (using default values):
+```
+attributeFamilies {
+    my-commit-log {
+        entity: "entity",
+        attributes: ["attribute1", "attribute2"]
+        storage: "gps://"${gcloud.projectId}"/my-commitlog"
+        type: "primary"
+        access: "commit-log"
+        pubsub {
+            subscription {
+                auto-create = true
+                ack-deadline = 600
+            }
+            deadline-max-ms = 60000
+        }
+    }
+}
+```

--- a/direct/io-pubsub/src/main/java/cz/o2/proxima/direct/pubsub/PubSubAccessor.java
+++ b/direct/io-pubsub/src/main/java/cz/o2/proxima/direct/pubsub/PubSubAccessor.java
@@ -66,11 +66,11 @@ class PubSubAccessor extends AbstractStorage implements DataAccessor {
     subscriptionAutoCreate = Optional.ofNullable(cfg.get(CFG_SUBSCRIPTION_AUTOCREATE))
         .map(Object::toString)
         .map(Boolean::valueOf)
-        .orElse(false);
+        .orElse(true);
     subscriptionAckDeadline = Optional.ofNullable(cfg.get(CFG_SUBSCRIPTION_ACK_DEADLINE))
         .map(Object::toString)
         .map(Integer::valueOf)
-        .orElse(10);
+        .orElse(600);
 
     Preconditions.checkArgument(
         !Strings.isNullOrEmpty(project), "Authority cannot be empty");

--- a/direct/io-pubsub/src/test/java/cz/o2/proxima/direct/pubsub/PubSubReaderTest.java
+++ b/direct/io-pubsub/src/test/java/cz/o2/proxima/direct/pubsub/PubSubReaderTest.java
@@ -65,7 +65,7 @@ public class PubSubReaderTest {
   private final Repository repo = ConfigRepository.of(ConfigFactory.load().resolve());
   private final DirectDataOperator direct = repo.asDataOperator(
       DirectDataOperator.class, op -> op.withExecutorFactory(
-          () -> Executors.newCachedThreadPool()));
+          Executors::newCachedThreadPool));
   private final Context context = direct.getContext();
   private final AttributeDescriptorImpl<?> attr;
   private final AttributeDescriptorImpl<?> wildcard;


### PR DESCRIPTION
- added topic check
- change default value for pubsub.subscription.auto-create - now true
- change default value for pubsub.subscription.ack-deadline - now 600
- added small part of documentation into README