### PR TITLE
[DO NOT MERGE] [proxima-beam] bump dependency to 2.20.0-SNAPSHOT

### DIFF
--- a/beam/io-pubsub/pom.xml
+++ b/beam/io-pubsub/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <grpc.version>1.17.1</grpc.version>
     <shadePattern>cz.o2.proxima.beam.io.pubsub</shadePattern>
-    <apache.beam.version.raw>2.19.0</apache.beam.version.raw>
+    <apache.beam.version.raw>2.20.0-SNAPSHOT</apache.beam.version.raw>
   </properties>
 
   <build>

--- a/beam/pom.xml
+++ b/beam/pom.xml
@@ -35,7 +35,7 @@
 
   <properties>
     <apache.beam.groupId>org.apache.beam</apache.beam.groupId>
-    <apache.beam.version>2.19.0-SNAPSHOT</apache.beam.version>
+    <apache.beam.version>2.20.0-SNAPSHOT</apache.beam.version>
     <apache.beam.groupId.raw>org.apache.beam</apache.beam.groupId.raw>
     <apache.beam.version.raw>${apache.beam.version}</apache.beam.version.raw>
   </properties>
@@ -98,9 +98,6 @@
     </profile>
     <profile>
       <id>useVendoredBeam</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
       <properties>
         <apache.beam.groupId>cz.o2.proxima.beam</apache.beam.groupId>
         <apache.beam.version>0.3-1d562f</apache.beam.version>
@@ -115,6 +112,9 @@
     </profile>
     <profile>
       <id>useNativeBeam</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
       <modules>
         <module>core</module>
         <module>core-testing</module>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <kafka.version>2.4.0</kafka.version>
     <proto.version>3.11.0</proto.version>
     <protoc.version>3.11.0</protoc.version>
-    <grpc.version>1.25.0</grpc.version>
+    <grpc.version>1.26.1</grpc.version>
     <guava.version>28.1-jre</guava.version>
     <commons-io.version>2.6</commons-io.version>
     <license-maven-plugin.version>3.0</license-maven-plugin.version>


### PR DESCRIPTION
Current 2.20.0-SNAPSHOT still doesn't work with shading. Will reiterate on this once new grpc vendor is out.