### PR TITLE
Modified to enable list of zookeeper hosts.

### DIFF
--- a/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
+++ b/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
@@ -40,6 +40,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -306,6 +307,26 @@ public class ZKGlobalWatermarkTrackerTest {
   public void testGetNodeName() {
     assertEquals("node", ZKGlobalWatermarkTracker.getNodeName("parent/node"));
     assertEquals("node", ZKGlobalWatermarkTracker.getNodeName("node"));
+  }
+
+  @Test
+  public void testZookeeperHostListParsing() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("zk.url", "zk://host1:2181,host2:2181,host3:2181/my/path");
+    tracker.parseZkUri(config);
+
+    assertEquals("host1:2181,host2:2181,host3:2181", tracker.zkConnectString);
+    assertEquals("/my/path/", tracker.parentNode);
+  }
+
+  @Test
+  public void testZookeeperSingleHostParsing() {
+    Map<String, Object> config = new HashMap<>();
+    config.put("zk.url", "zk://host1:2181/my/other-path");
+    tracker.parseZkUri(config);
+
+    assertEquals("host1:2181", tracker.zkConnectString);
+    assertEquals("/my/other-path/", tracker.parentNode);
   }
 
   private ZKGlobalWatermarkTracker createConnectionLossyTracker(String name) {

--- a/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
+++ b/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
@@ -312,8 +312,9 @@ public class ZKGlobalWatermarkTrackerTest {
   @Test
   public void testZookeeperHostListParsing() {
     Map<String, Object> config = new HashMap<>();
-    config.put("zk.url", "zk://host1:2181,host2:2181,host3:2181/my/path");
-    tracker.parseZkUri(config);
+    config.put(ZKGlobalWatermarkTracker.ZK_URI, "zk://host1:2181,host2:2181,host3:2181/my/path");
+    config.put(ZKGlobalWatermarkTracker.CFG_NAME, "test");
+    tracker.setup(config);
 
     assertEquals("host1:2181,host2:2181,host3:2181", tracker.zkConnectString);
     assertEquals("/my/path/", tracker.parentNode);
@@ -322,8 +323,9 @@ public class ZKGlobalWatermarkTrackerTest {
   @Test
   public void testZookeeperSingleHostParsing() {
     Map<String, Object> config = new HashMap<>();
-    config.put("zk.url", "zk://host1:2181/my/other-path");
-    tracker.parseZkUri(config);
+    config.put(ZKGlobalWatermarkTracker.ZK_URI, "zk://host1:2181/my/other-path");
+    config.put(ZKGlobalWatermarkTracker.CFG_NAME, "test");
+    tracker.setup(config);
 
     assertEquals("host1:2181", tracker.zkConnectString);
     assertEquals("/my/other-path/", tracker.parentNode);


### PR DESCRIPTION
In current state Proxima allows to define only single Zookeeper host even when Zookeeper supports list of hosts separated by comma. This modification should enable to define list of Zookeeper hosts.