### PR TITLE
[proxima-core] Prevent typos in attribute definition.

### DIFF
--- a/core/src/main/java/cz/o2/proxima/repository/ConfigRepository.java
+++ b/core/src/main/java/cz/o2/proxima/repository/ConfigRepository.java
@@ -756,6 +756,15 @@ public final class ConfigRepository extends Repository {
               toMap(ENTITIES + "." + entityName + "." + ATTRIBUTES + "." + key, value);
           if (settings.get(SCHEME) != null) {
             loadRegular(entityName, key, settings, entity);
+          } else if (!settings.containsKey(PROXY)) {
+            throw new IllegalStateException(
+                "Attribute "
+                    + key
+                    + " in entity "
+                    + entityName
+                    + " must be proxy or contains "
+                    + SCHEME
+                    + " definition.");
           }
         });
 
@@ -1730,7 +1739,7 @@ public final class ConfigRepository extends Repository {
               .getAllAttributes(includeProtected)
               .stream()
               .filter(a -> !((AttributeDescriptorBase<?>) a).isReplica() || allowReplicated)
-              .filter(a -> !((AttributeDescriptorBase<?>) a).isProxy() || allowProxies)
+              .filter(a -> !a.isProxy() || allowProxies)
               .collect(Collectors.toList());
     } else {
       attrDescs =

--- a/core/src/main/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactory.java
+++ b/core/src/main/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactory.java
@@ -34,7 +34,7 @@ public interface AbstractDataAccessorFactory<
     extends Serializable {
 
   /** Marker for acceptance of given URI to this factory. */
-  public enum Accept {
+  enum Accept {
 
     /** The URI is accepted. */
     ACCEPT,


### PR DESCRIPTION
User will now get exception like:
'Attribute name in entity user must be proxy or contains scheme definition.'
when attribute doesn't contains scheme or proxy definition