### PR TITLE
[proxima-core]: Added read/write methods into ValueSerializer.

### DIFF
--- a/core/src/main/java/cz/o2/proxima/scheme/BytesSerializer.java
+++ b/core/src/main/java/cz/o2/proxima/scheme/BytesSerializer.java
@@ -38,7 +38,7 @@ public class BytesSerializer implements ValueSerializerFactory {
   @SuppressWarnings("unchecked")
   @Override
   public <T> ValueSerializer<T> getValueSerializer(URI scheme) {
-    return (ValueSerializer)
+    return (ValueSerializer<T>)
         new ValueSerializer<byte[]>() {
 
           private static final long serialVersionUID = 1L;
@@ -77,6 +77,20 @@ public class BytesSerializer implements ValueSerializerFactory {
           @Override
           public SchemaTypeDescriptor<byte[]> getValueSchemaDescriptor() {
             return SchemaDescriptors.bytes().toTypeDescriptor();
+          }
+
+          @Override
+          public Object read(byte[] value) {
+            return value;
+          }
+
+          @Override
+          public Optional<byte[]> write(Object value) {
+            try {
+              return Optional.of((byte[]) value);
+            } catch (ClassCastException e) {
+              return Optional.empty();
+            }
           }
         };
   }

--- a/core/src/main/java/cz/o2/proxima/scheme/FloatSerializer.java
+++ b/core/src/main/java/cz/o2/proxima/scheme/FloatSerializer.java
@@ -38,7 +38,7 @@ public class FloatSerializer implements ValueSerializerFactory {
   @SuppressWarnings("unchecked")
   @Override
   public <T> ValueSerializer<T> getValueSerializer(URI specifier) {
-    return (ValueSerializer)
+    return (ValueSerializer<T>)
         new ValueSerializer<Float>() {
 
           private static final long serialVersionUID = 1L;
@@ -79,6 +79,20 @@ public class FloatSerializer implements ValueSerializerFactory {
           @Override
           public SchemaTypeDescriptor<Float> getValueSchemaDescriptor() {
             return SchemaDescriptors.floats().toTypeDescriptor();
+          }
+
+          @Override
+          public Object read(Float value) {
+            return value;
+          }
+
+          @Override
+          public Optional<Float> write(Object value) {
+            try {
+              return Optional.of((Float) value);
+            } catch (ClassCastException e) {
+              return Optional.empty();
+            }
           }
         };
   }

--- a/core/src/main/java/cz/o2/proxima/scheme/IntSerializer.java
+++ b/core/src/main/java/cz/o2/proxima/scheme/IntSerializer.java
@@ -38,7 +38,7 @@ public class IntSerializer implements ValueSerializerFactory {
   @SuppressWarnings("unchecked")
   @Override
   public <T> ValueSerializer<T> getValueSerializer(URI specifier) {
-    return (ValueSerializer)
+    return (ValueSerializer<T>)
         new ValueSerializer<Integer>() {
 
           private static final long serialVersionUID = 1L;
@@ -79,6 +79,20 @@ public class IntSerializer implements ValueSerializerFactory {
           @Override
           public SchemaTypeDescriptor<Integer> getValueSchemaDescriptor() {
             return SchemaDescriptors.integers().toTypeDescriptor();
+          }
+
+          @Override
+          public Object read(Integer value) {
+            return value;
+          }
+
+          @Override
+          public Optional<Integer> write(Object value) {
+            try {
+              return Optional.of((Integer) value);
+            } catch (ClassCastException e) {
+              return Optional.empty();
+            }
           }
         };
   }

--- a/core/src/main/java/cz/o2/proxima/scheme/LongSerializer.java
+++ b/core/src/main/java/cz/o2/proxima/scheme/LongSerializer.java
@@ -38,7 +38,7 @@ public class LongSerializer implements ValueSerializerFactory {
   @SuppressWarnings("unchecked")
   @Override
   public <T> ValueSerializer<T> getValueSerializer(URI specifier) {
-    return (ValueSerializer)
+    return (ValueSerializer<T>)
         new ValueSerializer<Long>() {
 
           private static final long serialVersionUID = 1L;
@@ -79,6 +79,20 @@ public class LongSerializer implements ValueSerializerFactory {
           @Override
           public SchemaTypeDescriptor<Long> getValueSchemaDescriptor() {
             return SchemaDescriptors.longs().toTypeDescriptor();
+          }
+
+          @Override
+          public Object read(Long value) {
+            return value;
+          }
+
+          @Override
+          public Optional<Long> write(Object value) {
+            try {
+              return Optional.of((Long) value);
+            } catch (ClassCastException e) {
+              return Optional.empty();
+            }
           }
         };
   }

--- a/core/src/main/java/cz/o2/proxima/scheme/ValueSerializer.java
+++ b/core/src/main/java/cz/o2/proxima/scheme/ValueSerializer.java
@@ -110,4 +110,26 @@ public interface ValueSerializer<T> extends Serializable {
     throw new UnsupportedOperationException(
         getClass() + " is not ported to provide a ValueSchemaDescriptor. " + "Please fill issue.");
   }
+
+  /**
+   * Read value and return it as Object with respect of schema.
+   *
+   * @param value
+   * @return value
+   */
+  default Object read(T value) {
+    throw new UnsupportedOperationException(
+        getClass() + " is not ported to support read method. " + "Please fill issue.");
+  }
+
+  /**
+   * Read value and create target object based on Object with respect of schema.
+   *
+   * @param value
+   * @return value
+   */
+  default Optional<T> write(Object value) {
+    throw new UnsupportedOperationException(
+        getClass() + " is not ported to support write method. " + "Please fill issue.");
+  }
 }

--- a/core/src/test/java/cz/o2/proxima/scheme/AlwaysFailSchemeParser.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/AlwaysFailSchemeParser.java
@@ -15,6 +15,7 @@
  */
 package cz.o2.proxima.scheme;
 
+import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
 import java.net.URI;
 import java.util.Optional;
 
@@ -53,6 +54,11 @@ public class AlwaysFailSchemeParser implements ValueSerializerFactory {
       @Override
       public boolean isUsable() {
         return true;
+      }
+
+      @Override
+      public SchemaTypeDescriptor<byte[]> getValueSchemaDescriptor() {
+        return SchemaDescriptors.bytes().toTypeDescriptor();
       }
     };
   }

--- a/core/src/test/java/cz/o2/proxima/scheme/BytesSerializerTest.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/BytesSerializerTest.java
@@ -73,4 +73,11 @@ public class BytesSerializerTest {
     SchemaTypeDescriptor<byte[]> descriptor = serializer.getValueSchemaDescriptor();
     assertEquals(AttributeValueType.BYTE, descriptor.getArrayTypeDescriptor().getValueType());
   }
+
+  @Test
+  public void testReadAndWriteValue() {
+    Optional<byte[]> v = serializer.write(new byte[] {1, 2});
+    assertTrue(v.isPresent());
+    assertArrayEquals(new byte[] {1, 2}, (byte[]) serializer.read(v.get()));
+  }
 }

--- a/core/src/test/java/cz/o2/proxima/scheme/FloatSerializerTest.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/FloatSerializerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
+import java.util.Optional;
 import org.junit.Test;
 
 /** Test {@link FloatSerializer}. */
@@ -73,5 +74,14 @@ public class FloatSerializerTest {
         serializer.<Float>getValueSerializer(null).getValueSchemaDescriptor();
     assertTrue(descriptor.isPrimitiveType());
     assertEquals(AttributeValueType.FLOAT, descriptor.getPrimitiveTypeDescriptor().getType());
+  }
+
+  @Test
+  public void testReadAndWriteValue() {
+    ValueSerializer<Float> s = serializer.getValueSerializer(null);
+    float value = 100F;
+    Optional<Float> v = s.write(value);
+    assertTrue(v.isPresent());
+    assertEquals(value, s.read(v.get()));
   }
 }

--- a/core/src/test/java/cz/o2/proxima/scheme/IntSerializerTest.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/IntSerializerTest.java
@@ -18,6 +18,7 @@ package cz.o2.proxima.scheme;
 import static org.junit.Assert.*;
 
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
+import java.util.Optional;
 import org.junit.Test;
 
 /** Test suite for {@link IntSerializer}. */
@@ -70,5 +71,14 @@ public class IntSerializerTest {
     SchemaTypeDescriptor<Integer> descriptor =
         serializer.<Integer>getValueSerializer(null).getValueSchemaDescriptor();
     assertTrue(descriptor.isPrimitiveType());
+  }
+
+  @Test
+  public void testReadAndWriteValue() {
+    ValueSerializer<Integer> s = serializer.getValueSerializer(null);
+    Integer value = 100;
+    Optional<Integer> v = s.write(value);
+    assertTrue(v.isPresent());
+    assertEquals(value, s.read(v.get()));
   }
 }

--- a/core/src/test/java/cz/o2/proxima/scheme/LongSerializerTest.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/LongSerializerTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
+import java.util.Optional;
 import org.junit.Test;
 
 /** Test suite for {@link LongSerializer}. */
@@ -72,5 +73,14 @@ public class LongSerializerTest {
     SchemaTypeDescriptor<Long> descriptor =
         serializer.<Long>getValueSerializer(null).getValueSchemaDescriptor();
     assertTrue(descriptor.isPrimitiveType());
+  }
+
+  @Test
+  public void testReadAndWriteValue() {
+    ValueSerializer<Long> s = serializer.getValueSerializer(null);
+    long value = 100L;
+    Optional<Long> v = s.write(value);
+    assertTrue(v.isPresent());
+    assertEquals(value, s.read(v.get()));
   }
 }

--- a/core/src/test/java/cz/o2/proxima/scheme/ValueSerializerTest.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/ValueSerializerTest.java
@@ -45,5 +45,7 @@ public class ValueSerializerTest {
     assertThrows(UnsupportedOperationException.class, () -> serializer.asJsonValue(new byte[] {}));
     assertThrows(UnsupportedOperationException.class, () -> serializer.fromJsonValue(""));
     assertThrows(UnsupportedOperationException.class, serializer::getValueSchemaDescriptor);
+    assertThrows(UnsupportedOperationException.class, () -> serializer.write(null));
+    assertThrows(UnsupportedOperationException.class, () -> serializer.read(new byte[] {}));
   }
 }

--- a/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/ProtoSerializerFactory.java
+++ b/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/ProtoSerializerFactory.java
@@ -158,5 +158,24 @@ public class ProtoSerializerFactory implements ValueSerializerFactory {
       }
       return valueSchemaDescriptor;
     }
+
+    @Override
+    public Object read(M value) {
+      return ProtoUtils.convertProtoObjectToMap(value);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Optional<M> write(Object value) {
+      try {
+        return Optional.of(
+            (M)
+                ProtoUtils.createProtoObject(
+                    (Map<String, Object>) value, getDefault().toBuilder()));
+      } catch (Exception e) {
+        log.warn("Unable to create protobuf object.", e);
+        return Optional.empty();
+      }
+    }
   }
 }

--- a/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/utils/ProtoUtils.java
+++ b/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/utils/ProtoUtils.java
@@ -15,24 +15,120 @@
  */
 package cz.o2.proxima.scheme.proto.utils;
 
+import com.google.protobuf.AbstractMessage;
+import com.google.protobuf.ByteString;
 import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.EnumValueDescriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
+import com.google.protobuf.Message;
+import com.google.protobuf.Message.Builder;
 import cz.o2.proxima.scheme.SchemaDescriptors;
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
 import cz.o2.proxima.scheme.SchemaDescriptors.StructureTypeDescriptor;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
+import javax.annotation.Nullable;
 
-@Slf4j
 public class ProtoUtils {
 
   private static Map<String, SchemaTypeDescriptor<?>> structCache = new ConcurrentHashMap<>();
 
   private ProtoUtils() {
     // no-op
+  }
+
+  public static <T extends AbstractMessage> Map<String, Object> convertProtoObjectToMap(T value) {
+    return value
+        .getAllFields()
+        .entrySet()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                entry -> entry.getKey().getName(),
+                entry -> mapFieldToObject(entry.getKey(), entry.getValue())));
+  }
+
+  public static Message createProtoObject(Map<String, Object> value, Builder builder) {
+    value.forEach(
+        (key, val) -> {
+          FieldDescriptor field = builder.getDescriptorForType().findFieldByName(key);
+          if (field == null) {
+            throw new IllegalArgumentException(
+                "Message "
+                    + builder.getDescriptorForType().toProto().getName()
+                    + " doesn't have field "
+                    + key);
+          }
+          if (value.containsKey(field.getName())) {
+            if (field.isRepeated()) {
+              ((Iterable<?>) val)
+                  .forEach(
+                      v ->
+                          builder.addRepeatedField(
+                              field, mapFieldValueToProtoValue(field, v, builder)));
+            } else {
+              builder.setField(field, mapFieldValueToProtoValue(field, val, builder));
+            }
+          }
+        });
+    return builder.build();
+  }
+
+  protected static Object mapFieldToObject(FieldDescriptor field, Object value) {
+    switch (field.getJavaType()) {
+      case BOOLEAN:
+      case FLOAT:
+      case DOUBLE:
+      case INT:
+      case LONG:
+      case STRING:
+        // for primitive types we can return value directly
+        return value;
+      case ENUM:
+        // enums is converted to string
+        return field.getEnumType().findValueByName(value.toString()).getName();
+      case BYTE_STRING:
+        return ((ByteString) value).toByteArray();
+      case MESSAGE:
+        if (value instanceof Iterable) {
+          // repeated message
+          return ((List<?>) value)
+              .stream()
+              .map(v -> convertProtoObjectToMap((AbstractMessage) v))
+              .collect(Collectors.toList());
+        } else {
+          return convertProtoObjectToMap((AbstractMessage) value);
+        }
+      default:
+        throw new IllegalStateException(
+            "Unable to convert proto field "
+                + field.getName()
+                + " with type "
+                + field.getJavaType());
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  protected static Object mapFieldValueToProtoValue(
+      FieldDescriptor field, Object value, @Nullable Builder builder) {
+    switch (field.getJavaType()) {
+      case ENUM:
+        return field.getEnumType().findValueByName(value.toString());
+      case MESSAGE:
+        Objects.requireNonNull(builder, "Builder can not be null.");
+        return createProtoObject((Map<String, Object>) value, builder.newBuilderForField(field));
+      case BYTE_STRING:
+        if (value instanceof byte[]) {
+          return ByteString.copyFrom((byte[]) value);
+        } else {
+          return value;
+        }
+      default:
+        return value;
+    }
   }
 
   public static <T> SchemaTypeDescriptor<T> convertProtoToSchema(Descriptor proto) {

--- a/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/ProtoSerializerFactoryTest.java
+++ b/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/ProtoSerializerFactoryTest.java
@@ -27,10 +27,12 @@ import cz.o2.proxima.scheme.proto.test.Scheme.Event;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Before;
 import org.junit.Test;
 
 /** Test for {@link ProtoSerializerFactory}. */
+@Slf4j
 public class ProtoSerializerFactoryTest {
 
   private final ValueSerializerFactory factory = new ProtoSerializerFactory();
@@ -83,5 +85,17 @@ public class ProtoSerializerFactoryTest {
   public void testGetSchemaDescriptor() {
     SchemaTypeDescriptor<Event> descriptor = serializer.getValueSchemaDescriptor();
     assertEquals(AttributeValueType.STRUCTURE, descriptor.getType());
+  }
+
+  @Test
+  public void testReadAndWrite() {
+    Event message =
+        Event.newBuilder()
+            .setGatewayId("gateway")
+            .setPayload(ByteString.copyFrom(new byte[] {0}))
+            .build();
+    Optional<Event> result = serializer.write(serializer.read(message));
+    assertTrue(result.isPresent());
+    assertEquals(message, result.get());
   }
 }

--- a/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/utils/ProtoUtilsTest.java
+++ b/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/utils/ProtoUtilsTest.java
@@ -15,16 +15,29 @@
  */
 package cz.o2.proxima.scheme.proto.utils;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.google.protobuf.ByteString;
 import cz.o2.proxima.scheme.AttributeValueType;
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
 import cz.o2.proxima.scheme.SchemaDescriptors.StructureTypeDescriptor;
 import cz.o2.proxima.scheme.proto.test.Scheme.Device;
+import cz.o2.proxima.scheme.proto.test.Scheme.Event;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage;
+import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage.Directions;
+import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage.InnerMessage;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
+@Slf4j
 public class ProtoUtilsTest {
 
   @Test
@@ -67,5 +80,157 @@ public class ProtoUtilsTest {
     assertEquals(
         AttributeValueType.STRUCTURE,
         descriptor.getField("repeated_inner_message").getArrayTypeDescriptor().getValueType());
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void simpleProtoToObject() {
+    Event event =
+        Event.newBuilder()
+            .setGatewayId("gateway value")
+            .setPayload(ByteString.copyFromUtf8("payload value"))
+            .build();
+    SchemaTypeDescriptor<Event> schema =
+        ProtoUtils.convertProtoToSchema(event.getDescriptorForType());
+    Map<String, Object> result = ProtoUtils.convertProtoObjectToMap(event);
+    assertEquals(schema.getStructureTypeDescriptor().getFields().size(), result.size());
+    assertTrue(result.containsKey("gatewayId"));
+    assertEquals("gateway value", result.get("gatewayId"));
+    assertArrayEquals("payload value".getBytes(), (byte[]) result.get("payload"));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void complexProtoToObject() {
+    ValueSchemeMessage message =
+        ValueSchemeMessage.newBuilder()
+            .addAllRepeatedString(Arrays.asList("repeated value 1", "repeated value 2"))
+            .addRepeatedInnerMessage(
+                InnerMessage.newBuilder()
+                    .addAllRepeatedInnerString(
+                        Arrays.asList("inner string value 1", "inner string value 2"))
+                    .setInnerEnum(Directions.LEFT)
+                    .setInnerDoubleType(100.0)
+                    .build())
+            .setInnerMessage(
+                InnerMessage.newBuilder()
+                    .addAllRepeatedInnerString(Arrays.asList("inner1", "inner2"))
+                    .build())
+            .setStringType("string value")
+            .setBooleanType(true)
+            .setLongType(100L)
+            .setIntType(10)
+            .build();
+
+    Map<String, Object> result = ProtoUtils.convertProtoObjectToMap(message);
+    log.info("result: {}", result);
+    assertEquals(
+        Arrays.asList("repeated value 1", "repeated value 2"), result.get("repeated_string"));
+    List<Map<String, Object>> repeated_inner_message_value =
+        (List<Map<String, Object>>) result.get("repeated_inner_message");
+    assertEquals(1, repeated_inner_message_value.size());
+    assertEquals(
+        Arrays.asList("inner string value 1", "inner string value 2"),
+        repeated_inner_message_value.get(0).get("repeated_inner_string"));
+    assertEquals(Directions.LEFT.name(), repeated_inner_message_value.get(0).get("inner_enum"));
+    assertEquals(100.0, repeated_inner_message_value.get(0).get("inner_double_type"));
+    assertEquals(
+        Arrays.asList("inner1", "inner2"),
+        ((Map<String, Object>) result.get("inner_message")).get("repeated_inner_string"));
+    assertTrue((Boolean) result.get("boolean_type"));
+    assertEquals(100L, result.get("long_type"));
+    assertEquals(10, result.get("int_type"));
+  }
+
+  @Test
+  public void createSimpleProtoTest() {
+    Map<String, Object> value =
+        new HashMap<String, Object>() {
+          {
+            put("gatewayId", "my-gatewayId");
+            put("payload", "my-payload".getBytes());
+          }
+        };
+    Event event = (Event) ProtoUtils.createProtoObject(value, Event.newBuilder());
+    log.debug("result: {}", event);
+    assertEquals("my-gatewayId", event.getGatewayId());
+    assertArrayEquals("my-payload".getBytes(), event.getPayload().toByteArray());
+  }
+
+  @Test
+  public void createComplexProtoTest() {
+
+    Map<String, Object> value =
+        new HashMap<String, Object>() {
+          {
+            put(
+                "repeated_string",
+                Arrays.asList("repeated_string value1", "repeated_string value2"));
+            put(
+                "repeated_inner_message",
+                Collections.singletonList(
+                    new HashMap<String, Object>() {
+                      {
+                        put("repeated_inner_string", Arrays.asList("inner value1", "inner value2"));
+                        put("inner_enum", "LEFT");
+                        put("inner_double_type", 100.0);
+                        put(
+                            "inner_inner_message",
+                            new HashMap<String, Object>() {
+                              {
+                                put("inner_float_type", 666.666F);
+                              }
+                            });
+                      }
+                    }));
+            put(
+                "inner_message",
+                new HashMap<String, Object>() {
+                  {
+                    put("inner_double_type", 3333);
+                  }
+                });
+
+            put("string_type", "test string");
+
+            put("boolean_type", false);
+            put("long_type", 20L);
+            put("int_type", 8);
+          }
+        };
+
+    log.debug("Data {}", value);
+    ValueSchemeMessage proto =
+        (ValueSchemeMessage) ProtoUtils.createProtoObject(value, ValueSchemeMessage.newBuilder());
+    log.debug("Created proto: {}", proto);
+    assertEquals(
+        Arrays.asList("repeated_string value1", "repeated_string value2"),
+        proto.getRepeatedStringList());
+    assertEquals(1, proto.getRepeatedInnerMessageCount());
+    assertEquals(
+        Arrays.asList("inner value1", "inner value2"),
+        proto.getRepeatedInnerMessageList().get(0).getRepeatedInnerStringList());
+    assertEquals(Directions.LEFT, proto.getRepeatedInnerMessageList().get(0).getInnerEnum());
+    assertEquals(100.0, proto.getRepeatedInnerMessageList().get(0).getInnerDoubleType(), 0.0001);
+    assertEquals(
+        666.666F,
+        proto.getRepeatedInnerMessageList().get(0).getInnerInnerMessage().getInnerFloatType(),
+        0.0001);
+    assertEquals(3333, proto.getInnerMessage().getInnerDoubleType(), 0.0001);
+    assertEquals("test string", proto.getStringType());
+    assertFalse(proto.getBooleanType());
+    assertEquals(20L, proto.getLongType());
+    assertEquals(8, proto.getIntType());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testTryToSetNotExistedField() {
+    ProtoUtils.createProtoObject(
+        new HashMap<String, Object>() {
+          {
+            put("not-existed-field", "value");
+          }
+        },
+        Event.newBuilder());
   }
 }


### PR DESCRIPTION
In this patch we introduce new methods which allows
to read and write values provided by ValueSerializer.
This is required for accessing fields in value with
respect of schema.