### PR TITLE
Allow access to AttributeFamily in DataAccessor

### DIFF
--- a/beam/core/src/main/java/cz/o2/proxima/beam/core/BeamDataOperator.java
+++ b/beam/core/src/main/java/cz/o2/proxima/beam/core/BeamDataOperator.java
@@ -434,7 +434,7 @@ public class BeamDataOperator implements DataOperator {
     URI uri = family.getStorageUri();
     return loader
         .findForUri(uri)
-        .map(f -> f.createAccessor(this, family.getEntity(), uri, family.getCfg()))
+        .map(f -> f.createAccessor(this, family))
         .orElseThrow(
             () -> new IllegalStateException("No accessor for URI " + family.getStorageUri()));
   }

--- a/core/src/main/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactory.java
+++ b/core/src/main/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactory.java
@@ -16,6 +16,7 @@
 package cz.o2.proxima.storage.internal;
 
 import cz.o2.proxima.annotations.Internal;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import cz.o2.proxima.repository.DataOperator;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
@@ -69,6 +70,29 @@ public interface AbstractDataAccessorFactory<
    * @param uri the URI to create accessor for
    * @param cfg optional additional configuration
    * @return {@link AbstractDataAccessor} for given operator and family
+   * @deprecated replaced with {@link AbstractDataAccessorFactory#createAccessor(DataOperator,
+   *     AttributeFamilyDescriptor)}
    */
-  T createAccessor(OP operator, EntityDescriptor entity, URI uri, Map<String, Object> cfg);
+  @Deprecated
+  default T createAccessor(OP operator, EntityDescriptor entity, URI uri, Map<String, Object> cfg) {
+    throw new IllegalStateException(getClass() + " must override createAccessor method.");
+  }
+
+  /**
+   * Create the accessor for give {@link AttributeFamilyDescriptor}.
+   *
+   * <p>Default implementation calls {@link AbstractDataAccessorFactory#createAccessor(DataOperator,
+   * EntityDescriptor, URI, Map)} to keep backward compatibility.
+   *
+   * @param operator operator to create the accessor for
+   * @param familyDescriptor attribute family descriptor
+   * @return {@link AbstractDataAccessor} for given operator and family
+   */
+  default T createAccessor(OP operator, AttributeFamilyDescriptor familyDescriptor) {
+    return createAccessor(
+        operator,
+        familyDescriptor.getEntity(),
+        familyDescriptor.getStorageUri(),
+        familyDescriptor.getCfg());
+  }
 }

--- a/core/src/test/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactoryTest.java
+++ b/core/src/test/java/cz/o2/proxima/storage/internal/AbstractDataAccessorFactoryTest.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017-2021 O2 Czech Republic, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.o2.proxima.storage.internal;
+
+import static org.junit.Assert.*;
+
+import com.typesafe.config.ConfigFactory;
+import cz.o2.proxima.repository.EntityDescriptor;
+import cz.o2.proxima.repository.Repository;
+import cz.o2.proxima.repository.TestDataOperatorFactory.TestDataOperator;
+import cz.o2.proxima.storage.internal.AbstractDataAccessorFactory.Accept;
+import cz.o2.proxima.util.Optionals;
+import cz.o2.proxima.util.TestUtils;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Map;
+import lombok.EqualsAndHashCode;
+import org.junit.Test;
+
+// To make sonar happy...
+public class AbstractDataAccessorFactoryTest {
+
+  private final Repository repository =
+      Repository.ofTest(ConfigFactory.load("test-reference.conf"));
+  private final TestDataAccessorFactory factory = new TestDataAccessorFactory();
+
+  @EqualsAndHashCode
+  private static class TestDataAccessorFactory
+      implements AbstractDataAccessor,
+          AbstractDataAccessorFactory<TestDataOperator, TestDataAccessorFactory> {
+
+    @Override
+    public void setup(Repository repo) {}
+
+    @Override
+    public Accept accepts(URI uri) {
+      return uri.getScheme().equalsIgnoreCase("test") ? Accept.ACCEPT : Accept.REJECT;
+    }
+
+    @Override
+    public TestDataAccessorFactory createAccessor(
+        TestDataOperator operator, EntityDescriptor entity, URI uri, Map<String, Object> cfg) {
+      return new TestDataAccessorFactory();
+    }
+
+    @Override
+    public URI getUri() {
+      return URI.create("test:///");
+    }
+  }
+
+  @Test
+  public void contractTest() throws IOException, ClassNotFoundException {
+    URI testUri = URI.create("test:///");
+    TestUtils.assertSerializable(factory);
+    assertEquals(Accept.ACCEPT, factory.accepts(testUri));
+    TestDataOperator operator = repository.getOrCreateOperator(TestDataOperator.class);
+    TestDataAccessorFactory accessor =
+        factory.createAccessor(operator, Optionals.get(repository.getAllFamilies().findAny()));
+    accessor.setup(repository);
+    assertEquals(Accept.ACCEPT, accessor.accepts(testUri));
+    assertEquals(Accept.REJECT, accessor.accepts(URI.create("foo:///")));
+  }
+}

--- a/direct/core/src/test/java/cz/o2/proxima/direct/core/DirectDataOperatorTest.java
+++ b/direct/core/src/test/java/cz/o2/proxima/direct/core/DirectDataOperatorTest.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -217,8 +218,7 @@ public class DirectDataOperatorTest {
                   fail("Missing _e.raw-abc stored");
                   return null;
                 });
-
-    assertEquals("test", new String((byte[]) kv.getValue()));
+    assertEquals("test", new String(Objects.requireNonNull(kv.getValue())));
   }
 
   @Test

--- a/direct/core/src/test/java/cz/o2/proxima/direct/storage/InMemStorage.java
+++ b/direct/core/src/test/java/cz/o2/proxima/direct/storage/InMemStorage.java
@@ -976,7 +976,6 @@ public class InMemStorage implements DataAccessorFactory {
     final OnlineAttributeWriter.Factory<?> writerFactory = new Writer(entity, uri).asFactory();
     final CommitLogReader.Factory<?> commitLogReaderFactory =
         new InMemCommitLogReader(entity, uri, op.getContext().getExecutorFactory()).asFactory();
-    @SuppressWarnings({"unchecked", "rawtypes"})
     final ReaderFactory readerFactory =
         new Reader(entity, uri, op.getContext().getExecutorFactory()).asFactory();
     final CachedView.Factory cachedViewFactory =

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <surefire.forkCount>8</surefire.forkCount>
     <surefire.cmdArgs>-DLOG_LEVEL=WARN</surefire.cmdArgs>
     <!-- sonar config -->
-    <jacoco.version>0.8.5</jacoco.version>
+    <jacoco.version>0.8.6</jacoco.version>
     <sonar.organization>datadriven</sonar.organization>
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.login>21787938b088389dc6edfdf1cf4008e91b81e70b</sonar.login>


### PR DESCRIPTION
`DataAccessor` should have access to `AttributeFamilyDescriptor` not just `EntityDescriptor` and configuration.