### PR TITLE
Check attribute names in entity for possible duplicates with wildcards

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -120,6 +120,13 @@
       <version>${guava.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/core/src/main/java/cz/o2/proxima/repository/EntityDescriptor.java
+++ b/core/src/main/java/cz/o2/proxima/repository/EntityDescriptor.java
@@ -38,6 +38,16 @@ public interface EntityDescriptor extends Serializable {
     private final Map<String, AttributeDescriptor<?>> attributes = new HashMap<>();
 
     public Builder addAttribute(AttributeDescriptor<?> attr) {
+      String nameToCheck = attr.toAttributePrefix(false);
+      if (!attr.isWildcard()) {
+        nameToCheck = String.format("%s.*", attr.getName());
+      }
+      if (attributes.containsKey(nameToCheck)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Attribute name [%s] must be unique in entity [%s]. Duplicated with [%s] or [%s.*].",
+                attr.getName(), attr.getEntity(), nameToCheck, attr.toAttributePrefix(false)));
+      }
       attributes.put(attr.getName(), attr);
       return this;
     }

--- a/core/src/test/java/cz/o2/proxima/repository/EntityDescriptorBuilderTest.java
+++ b/core/src/test/java/cz/o2/proxima/repository/EntityDescriptorBuilderTest.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017-2021 O2 Czech Republic, a.s.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package cz.o2.proxima.repository;
+
+import com.typesafe.config.ConfigFactory;
+import java.net.URI;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class EntityDescriptorBuilderTest {
+  final Repository repository = Repository.of(ConfigFactory.defaultApplication().resolve());
+
+  @Parameters({"attr.*,attr", "attr,attr.*"})
+  @Test(expected = IllegalArgumentException.class)
+  public void testBuildEntityWithDuplicateAttributeName(String first, String second) {
+    EntityDescriptor.newBuilder()
+        .addAttribute(createSimpleAttributeWithName(first))
+        .addAttribute(createSimpleAttributeWithName(second));
+  }
+
+  private AttributeDescriptor<byte[]> createSimpleAttributeWithName(String name) {
+    return AttributeDescriptor.newBuilder(repository)
+        .setEntity("e")
+        .setName(name)
+        .setSchemeUri(URI.create("bytes:///"))
+        .build();
+  }
+}


### PR DESCRIPTION
Warning: this is possible breaking change where now we disallow to have
wildcard and normal attribute with same name.

This will not be valid anymore:
```
entities {
    entitiName {
	attributes {
	    attribute: {...}
	    "attribute.*": {...}
	}
    }
}
```