### PR TITLE
Migrate bulk IOs to accept AttributeFamilyDescriptor + fix shading

### DIFF
--- a/core/src/test/java/cz/o2/proxima/scheme/AlwaysFailSchemeParser.java
+++ b/core/src/test/java/cz/o2/proxima/scheme/AlwaysFailSchemeParser.java
@@ -15,6 +15,7 @@
  */
 package cz.o2.proxima.scheme;
 
+import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
 import java.net.URI;
 import java.util.Optional;
 
@@ -53,6 +54,11 @@ public class AlwaysFailSchemeParser implements ValueSerializerFactory {
       @Override
       public boolean isUsable() {
         return true;
+      }
+
+      @Override
+      public SchemaTypeDescriptor<byte[]> getValueSchemaDescriptor() {
+        return SchemaDescriptors.bytes().toTypeDescriptor();
       }
     };
   }

--- a/core/src/test/java/cz/o2/proxima/util/TestUtils.java
+++ b/core/src/test/java/cz/o2/proxima/util/TestUtils.java
@@ -19,11 +19,21 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import cz.o2.proxima.repository.AttributeDescriptor;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor.Builder;
+import cz.o2.proxima.repository.EntityDescriptor;
+import cz.o2.proxima.storage.AccessType;
+import cz.o2.proxima.storage.StorageType;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 public class TestUtils {
 
@@ -94,5 +104,55 @@ public class TestUtils {
     assertEquals(first, second);
     assertEquals("Hashcode should be same.", first.hashCode(), second.hashCode());
     assertNotEquals(first, new Object());
+  }
+
+  /**
+   * Create {@link AttributeFamilyDescriptor} for test purpose.
+   *
+   * @param entity entity
+   * @param uri storage URI
+   * @return attribute family descriptor
+   */
+  public static AttributeFamilyDescriptor createTestFamily(EntityDescriptor entity, URI uri) {
+    return createTestFamily(entity, uri, Collections.emptyList(), Collections.emptyMap());
+  }
+
+  /**
+   * Create {@link AttributeFamilyDescriptor} for test purpose.
+   *
+   * @param entity entity
+   * @param uri storage URI
+   * @param cfg configuration
+   * @return attribute family descriptor
+   */
+  public static AttributeFamilyDescriptor createTestFamily(
+      EntityDescriptor entity, URI uri, Map<String, Object> cfg) {
+    return createTestFamily(entity, uri, Collections.emptyList(), cfg);
+  }
+
+  /**
+   * Create {@link AttributeFamilyDescriptor} for test purpose.
+   *
+   * @param entity entity
+   * @param uri storage URI
+   * @param attr attributes
+   * @param cfg configuration
+   * @return attribute family descriptor
+   */
+  public static AttributeFamilyDescriptor createTestFamily(
+      EntityDescriptor entity,
+      URI uri,
+      List<AttributeDescriptor<?>> attr,
+      Map<String, Object> cfg) {
+    Builder builder =
+        AttributeFamilyDescriptor.newBuilder()
+            .setName("test-family")
+            .setEntity(entity)
+            .setStorageUri(uri)
+            .setType(StorageType.PRIMARY)
+            .setAccess(AccessType.from("read-only"))
+            .setCfg(cfg);
+    attr.forEach(builder::addAttribute);
+    return builder.build();
   }
 }

--- a/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BlobLogReaderTest.java
+++ b/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BlobLogReaderTest.java
@@ -15,7 +15,9 @@
  */
 package cz.o2.proxima.direct.blob;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import com.google.common.collect.Lists;
 import com.typesafe.config.ConfigFactory;
@@ -64,7 +66,7 @@ public class BlobLogReaderTest {
   public void setUp() {
     accessor =
         new TestBlobStorageAccessor(
-            gateway, URI.create("blob-test://bucket/path"), Collections.emptyMap());
+            TestUtils.createTestFamily(gateway, URI.create("blob-test://bucket/path")));
   }
 
   @Test

--- a/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BlobStorageAccessorTest.java
+++ b/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BlobStorageAccessorTest.java
@@ -15,7 +15,7 @@
  */
 package cz.o2.proxima.direct.blob;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertTrue;
 
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.direct.blob.TestBlobStorageAccessor.TestBlob;
@@ -27,7 +27,6 @@ import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.util.TestUtils;
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
 import org.junit.Test;
 
 public class BlobStorageAccessorTest {
@@ -40,7 +39,7 @@ public class BlobStorageAccessorTest {
   public void testNamingConventionWithBucket() {
     BlobStorageAccessor accessor =
         new TestBlobStorageAccessor(
-            entity, URI.create("blob-test://bucket/path"), Collections.emptyMap());
+            TestUtils.createTestFamily(entity, URI.create("blob-test://bucket/path")));
     NamingConvention convention = accessor.getNamingConvention();
     assertTrue(convention.nameOf(1500000000000L).startsWith("/2017/07/"));
   }
@@ -49,7 +48,7 @@ public class BlobStorageAccessorTest {
   public void testNamingConventionWithBucketAndNoPath() {
     BlobStorageAccessor accessor =
         new TestBlobStorageAccessor(
-            entity, URI.create("blob-test://bucket"), Collections.emptyMap());
+            TestUtils.createTestFamily(entity, URI.create("blob-test://bucket")));
     NamingConvention convention = accessor.getNamingConvention();
     assertTrue(convention.nameOf(1500000000000L).startsWith("/2017/07/"));
   }
@@ -58,7 +57,7 @@ public class BlobStorageAccessorTest {
   public void testBlobPathSerializable() throws IOException, ClassNotFoundException {
     TestBlobStorageAccessor accessor =
         new TestBlobStorageAccessor(
-            entity, URI.create("blob-test://bucket"), Collections.emptyMap());
+            TestUtils.createTestFamily(entity, URI.create("blob-test://bucket")));
 
     FileSystem fs = accessor.new TestBlobFileSystem();
     TestBlob blob = accessor.new TestBlob("test");

--- a/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BulkBlobWriterTest.java
+++ b/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/BulkBlobWriterTest.java
@@ -15,8 +15,11 @@
  */
 package cz.o2.proxima.direct.blob;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.direct.blob.TestBlobStorageAccessor.BlobWriter;
@@ -37,7 +40,6 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -117,9 +119,7 @@ public class BulkBlobWriterTest implements Serializable {
   void initWriter(Map<String, Object> cfg) {
     accessor =
         new TestBlobStorageAccessor(
-            entity,
-            URI.create("blob-test://bucket/path"),
-            cfg,
+            TestUtils.createTestFamily(entity, URI.create("blob-test://bucket/path"), cfg),
             () -> Optional.ofNullable(latch.get()).ifPresent(CountDownLatch::countDown),
             onFlushToBlob) {
           @Override
@@ -365,9 +365,7 @@ public class BulkBlobWriterTest implements Serializable {
   public void testAsFactorySerializable() throws IOException, ClassNotFoundException {
     accessor =
         new TestBlobStorageAccessor(
-            entity,
-            URI.create("blob-test://bucket/path"),
-            Collections.emptyMap(),
+            TestUtils.createTestFamily(entity, URI.create("blob-test://bucket/path")),
             () -> {},
             new AtomicReference<>());
     BlobWriter writer = accessor.new BlobWriter(direct.getContext());

--- a/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/TestBlobStorageAccessor.java
+++ b/direct/io-blob/src/test/java/cz/o2/proxima/direct/blob/TestBlobStorageAccessor.java
@@ -20,7 +20,7 @@ import cz.o2.proxima.direct.bulk.FileSystem;
 import cz.o2.proxima.direct.bulk.Path;
 import cz.o2.proxima.direct.core.AttributeWriterBase;
 import cz.o2.proxima.direct.core.Context;
-import cz.o2.proxima.repository.EntityDescriptor;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import cz.o2.proxima.storage.StreamElement;
 import cz.o2.proxima.util.ExceptionUtils;
 import java.io.ByteArrayInputStream;
@@ -114,14 +114,14 @@ public class TestBlobStorageAccessor extends BlobStorageAccessor {
     @Override
     public Stream<Path> list(long minTs, long maxTs) {
       return outputStreams
-          .entrySet()
+          .keySet()
           .stream()
           .filter(
-              e ->
+              byteArrayOutputStream ->
                   TestBlobStorageAccessor.this
                       .getNamingConvention()
-                      .isInRange(e.getKey(), minTs, maxTs))
-          .map(e -> new TestBlobPath(fs, new TestBlob(e.getKey())));
+                      .isInRange(byteArrayOutputStream, minTs, maxTs))
+          .map(byteArrayOutputStream -> new TestBlobPath(fs, new TestBlob(byteArrayOutputStream)));
     }
 
     @Override
@@ -193,18 +193,16 @@ public class TestBlobStorageAccessor extends BlobStorageAccessor {
   private final Map<String, ByteArrayOutputStream> outputStreams = new ConcurrentHashMap<>();
   private final TestBlobFileSystem fs;
 
-  public TestBlobStorageAccessor(EntityDescriptor entityDesc, URI uri, Map<String, Object> cfg) {
-    this(entityDesc, uri, cfg, null, new AtomicReference<>());
+  public TestBlobStorageAccessor(AttributeFamilyDescriptor family) {
+    this(family, null, new AtomicReference<>());
   }
 
   public TestBlobStorageAccessor(
-      EntityDescriptor entityDesc,
-      URI uri,
-      Map<String, Object> cfg,
+      AttributeFamilyDescriptor family,
       @Nullable Runnable afterWrite,
       AtomicReference<Runnable> preWrite) {
 
-    super(entityDesc, uri, cfg);
+    super(family);
     fs = new TestBlobFileSystem(afterWrite, preWrite);
   }
 

--- a/direct/io-bulkfs/src/main/java/cz/o2/proxima/direct/bulk/FileFormat.java
+++ b/direct/io-bulkfs/src/main/java/cz/o2/proxima/direct/bulk/FileFormat.java
@@ -15,6 +15,7 @@
  */
 package cz.o2.proxima.direct.bulk;
 
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import cz.o2.proxima.repository.EntityDescriptor;
 import java.io.IOException;
 import java.io.Serializable;
@@ -40,6 +41,15 @@ public interface FileFormat extends Serializable {
    */
   static FileFormat json(boolean gzip) {
     return new JsonFormat(gzip);
+  }
+
+  /**
+   * Setup FileFormat for given {@link AttributeFamilyDescriptor}.
+   *
+   * @param family attribute family
+   */
+  default void setup(AttributeFamilyDescriptor family) {
+    // no-op
   }
 
   /**

--- a/direct/io-bulkfs/src/test/java/cz/o2/proxima/direct/bulk/BinaryBlobFormatTest.java
+++ b/direct/io-bulkfs/src/test/java/cz/o2/proxima/direct/bulk/BinaryBlobFormatTest.java
@@ -24,7 +24,6 @@ import cz.o2.proxima.direct.bulk.BinaryBlobFormat.BinaryBlobReader;
 import cz.o2.proxima.direct.bulk.BinaryBlobFormat.BinaryBlobWriter;
 import cz.o2.proxima.gcloud.storage.proto.Serialization.Header;
 import cz.o2.proxima.repository.AttributeDescriptor;
-import cz.o2.proxima.repository.AttributeDescriptorBase;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
 import cz.o2.proxima.storage.StreamElement;
@@ -86,8 +85,8 @@ public class BinaryBlobFormatTest {
     this.entity =
         EntityDescriptor.newBuilder()
             .setName("dummy")
-            .addAttribute((AttributeDescriptorBase<?>) attr)
-            .addAttribute((AttributeDescriptorBase<?>) wildcard)
+            .addAttribute(attr)
+            .addAttribute(wildcard)
             .build();
   }
 

--- a/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageAccessor.java
+++ b/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageAccessor.java
@@ -21,20 +21,18 @@ import cz.o2.proxima.direct.bulk.FileSystem;
 import cz.o2.proxima.direct.core.AttributeWriterBase;
 import cz.o2.proxima.direct.core.Context;
 import cz.o2.proxima.direct.core.DataAccessor;
-import cz.o2.proxima.repository.EntityDescriptor;
-import java.net.URI;
-import java.util.Map;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import java.util.Optional;
 
 /** A {@link DataAccessor} for gcloud storage. */
 class GCloudStorageAccessor extends BlobStorageAccessor {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private final FileSystem fs;
 
-  public GCloudStorageAccessor(EntityDescriptor entityDesc, URI uri, Map<String, Object> cfg) {
-    super(entityDesc, uri, cfg);
+  public GCloudStorageAccessor(AttributeFamilyDescriptor family) {
+    super(family);
     this.fs = new GCloudFileSystem(this);
   }
 

--- a/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageDescriptor.java
+++ b/direct/io-gcloud-storage/src/main/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageDescriptor.java
@@ -18,20 +18,20 @@ package cz.o2.proxima.direct.gcloud.storage;
 import cz.o2.proxima.direct.core.DataAccessor;
 import cz.o2.proxima.direct.core.DataAccessorFactory;
 import cz.o2.proxima.direct.core.DirectDataOperator;
-import cz.o2.proxima.repository.EntityDescriptor;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import java.net.URI;
-import java.util.Map;
+import lombok.EqualsAndHashCode;
 
 /** A {@link DataAccessorFactory} for gcloud storage. */
+@EqualsAndHashCode
 public class GCloudStorageDescriptor implements DataAccessorFactory {
 
   private static final long serialVersionUID = 1L;
 
   @Override
   public DataAccessor createAccessor(
-      DirectDataOperator direct, EntityDescriptor entityDesc, URI uri, Map<String, Object> cfg) {
-
-    return new GCloudStorageAccessor(entityDesc, uri, cfg);
+      DirectDataOperator operator, AttributeFamilyDescriptor familyDescriptor) {
+    return new GCloudStorageAccessor(familyDescriptor);
   }
 
   @Override

--- a/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudFileSystemTest.java
+++ b/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudFileSystemTest.java
@@ -28,9 +28,9 @@ import cz.o2.proxima.direct.bulk.NamingConvention;
 import cz.o2.proxima.direct.bulk.Path;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
+import cz.o2.proxima.util.TestUtils;
 import java.net.URI;
 import java.time.Duration;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,7 +44,7 @@ public class GCloudFileSystemTest {
       Repository.of(ConfigFactory.load("test-reference.conf").resolve());
   private final EntityDescriptor entity = repo.getEntity("gateway");
   private final GCloudStorageAccessor accessor =
-      new GCloudStorageAccessor(entity, URI.create("gs://bucket/path"), Collections.emptyMap());
+      new GCloudStorageAccessor(TestUtils.createTestFamily(entity, URI.create("gs://bucket/path")));
   private final Map<String, Blob> blobs = new HashMap<>();
   private final FileFormat format = FileFormat.blob(true);
   private final NamingConvention naming =
@@ -67,14 +67,12 @@ public class GCloudFileSystemTest {
               String tmp = option.toString();
               int valueIndex = tmp.indexOf("value=");
               String prefix = valueIndex > 0 ? tmp.substring(valueIndex + 6, tmp.length() - 1) : "";
-              Page<Blob> page =
-                  asPage(
-                      blobs
-                          .entrySet()
-                          .stream()
-                          .filter(entry -> entry.getKey().startsWith(prefix))
-                          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
-              return page;
+              return asPage(
+                  blobs
+                      .entrySet()
+                      .stream()
+                      .filter(entry -> entry.getKey().startsWith(prefix))
+                      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
             })
         .when(ret)
         .list(anyString(), any());
@@ -98,7 +96,7 @@ public class GCloudFileSystemTest {
   public void testList() {
     long now = System.currentTimeMillis();
     for (int i = 0; i < 100; i++) {
-      String name = "path" + naming.nameOf(now + 86400000 * i);
+      String name = "path" + naming.nameOf(now + 86400000L * i);
       Blob blob = mockBlob(name);
       blobs.put(name, blob);
     }
@@ -110,7 +108,7 @@ public class GCloudFileSystemTest {
   public void testListRange() {
     long now = 1500000000000L;
     for (int i = 0; i < 100; i++) {
-      String name = "path" + naming.nameOf(now + 86400000 * i);
+      String name = "path" + naming.nameOf(now + 86400000L * i);
       Blob blob = mockBlob(name);
       blobs.put(name, blob);
     }

--- a/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudLogReaderTest.java
+++ b/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudLogReaderTest.java
@@ -47,7 +47,8 @@ public class GCloudLogReaderTest {
   final DirectDataOperator direct = repo.getOrCreateOperator(DirectDataOperator.class);
   final EntityDescriptor gateway = repo.getEntity("gateway");
   final GCloudStorageAccessor accessor =
-      new GCloudStorageAccessor(gateway, URI.create("gs://bucket/path"), cfg());
+      new GCloudStorageAccessor(
+          TestUtils.createTestFamily(gateway, URI.create("gs://bucket/path"), cfg()));
 
   private static Map<String, Object> cfg() {
     return new HashMap<String, Object>() {

--- a/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageDescriptorTest.java
+++ b/direct/io-gcloud-storage/src/test/java/cz/o2/proxima/direct/gcloud/storage/GCloudStorageDescriptorTest.java
@@ -15,34 +15,32 @@
  */
 package cz.o2.proxima.direct.gcloud.storage;
 
-import com.typesafe.config.ConfigFactory;
-import cz.o2.proxima.repository.EntityDescriptor;
-import cz.o2.proxima.repository.Repository;
+import static org.junit.Assert.assertEquals;
+
+import cz.o2.proxima.direct.core.DataAccessorFactory;
+import cz.o2.proxima.storage.internal.AbstractDataAccessorFactory.Accept;
 import cz.o2.proxima.util.TestUtils;
 import java.io.IOException;
-import java.io.Serializable;
 import java.net.URI;
 import org.junit.Test;
 
-public class GCloudBlobPathTest implements Serializable {
+public class GCloudStorageDescriptorTest {
 
-  Repository repo = Repository.ofTest(ConfigFactory.load("test-reference.conf").resolve());
-  EntityDescriptor entity = repo.getEntity("gateway");
+  private final DataAccessorFactory factory = new GCloudStorageDescriptor();
 
   @Test
   public void testSerializable() throws IOException, ClassNotFoundException {
-    GCloudFileSystem fs =
-        new GCloudFileSystem(
-            new GCloudStorageAccessor(
-                TestUtils.createTestFamily(entity, URI.create("gs://bucket"))));
-    GCloudBlobPath path =
-        new GCloudBlobPath(fs, null) {
-          @Override
-          public String getBlobName() {
-            return "name";
-          }
-        };
-    GCloudBlobPath path2 = TestUtils.assertSerializable(path);
-    TestUtils.assertHashCodeAndEquals(path, path2);
+    TestUtils.assertSerializable(factory);
+  }
+
+  @Test
+  public void testHashCodeAndEquals() {
+    TestUtils.assertHashCodeAndEquals(factory, new GCloudStorageDescriptor());
+  }
+
+  @Test
+  public void testAcceptSchema() {
+    assertEquals(Accept.ACCEPT, factory.accepts(URI.create("gs://bucket/path")));
+    assertEquals(Accept.REJECT, factory.accepts(URI.create("file:///")));
   }
 }

--- a/direct/io-s3/pom.xml
+++ b/direct/io-s3/pom.xml
@@ -74,6 +74,10 @@
               <pattern>org.joda.time.</pattern>
               <shadedPattern>${shadePattern}.org.joda.time.</shadedPattern>
             </relocation>
+            <relocation>
+              <pattern>org.apache.http.</pattern>
+              <shadedPattern>${shadePattern}.org.apache.http</shadedPattern>
+            </relocation>
           </relocations>
         </configuration>
         <executions>

--- a/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Accessor.java
+++ b/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Accessor.java
@@ -21,9 +21,7 @@ import cz.o2.proxima.direct.bulk.FileSystem;
 import cz.o2.proxima.direct.core.AttributeWriterBase;
 import cz.o2.proxima.direct.core.Context;
 import cz.o2.proxima.direct.core.DataAccessor;
-import cz.o2.proxima.repository.EntityDescriptor;
-import java.net.URI;
-import java.util.Map;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import java.util.Optional;
 
 /** A {@link DataAccessor} for gcloud storage. */
@@ -33,8 +31,8 @@ class S3Accessor extends BlobStorageAccessor {
 
   private S3FileSystem fs;
 
-  public S3Accessor(EntityDescriptor entityDesc, URI uri, Map<String, Object> cfg) {
-    super(entityDesc, uri, cfg);
+  public S3Accessor(AttributeFamilyDescriptor family) {
+    super(family);
   }
 
   @Override

--- a/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3StorageDescriptor.java
+++ b/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3StorageDescriptor.java
@@ -18,9 +18,8 @@ package cz.o2.proxima.direct.s3;
 import cz.o2.proxima.direct.core.DataAccessor;
 import cz.o2.proxima.direct.core.DataAccessorFactory;
 import cz.o2.proxima.direct.core.DirectDataOperator;
-import cz.o2.proxima.repository.EntityDescriptor;
+import cz.o2.proxima.repository.AttributeFamilyDescriptor;
 import java.net.URI;
-import java.util.Map;
 
 /** A {@link DataAccessorFactory} for gcloud storage. */
 public class S3StorageDescriptor implements DataAccessorFactory {
@@ -29,9 +28,8 @@ public class S3StorageDescriptor implements DataAccessorFactory {
 
   @Override
   public DataAccessor createAccessor(
-      DirectDataOperator direct, EntityDescriptor entityDesc, URI uri, Map<String, Object> cfg) {
-
-    return new S3Accessor(entityDesc, uri, cfg);
+      DirectDataOperator operator, AttributeFamilyDescriptor familyDescriptor) {
+    return new S3Accessor(familyDescriptor);
   }
 
   @Override

--- a/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3BlobPathTest.java
+++ b/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3BlobPathTest.java
@@ -95,7 +95,10 @@ public class S3BlobPathTest implements Serializable {
     Context context = op.getContext();
     S3FileSystem fs =
         new S3FileSystem(
-            new S3Accessor(entity, URI.create("gs://bucket"), S3FileSystemTest.cfg()), context);
+            new S3Accessor(
+                TestUtils.createTestFamily(
+                    entity, URI.create("s3://bucket"), S3FileSystemTest.cfg())),
+            context);
     S3BlobPath path = new S3BlobPath(context, fs, new S3Blob("name", fs));
     S3BlobPath path2 = TestUtils.assertSerializable(path);
     TestUtils.assertHashCodeAndEquals(path, path2);

--- a/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3FileSystemTest.java
+++ b/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3FileSystemTest.java
@@ -33,6 +33,7 @@ import cz.o2.proxima.direct.bulk.Path;
 import cz.o2.proxima.direct.core.DirectDataOperator;
 import cz.o2.proxima.repository.EntityDescriptor;
 import cz.o2.proxima.repository.Repository;
+import cz.o2.proxima.util.TestUtils;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.URI;
@@ -72,7 +73,8 @@ public class S3FileSystemTest {
   @Before
   public void setUp() {
     Map<String, Blob> blobs = new HashMap<>();
-    S3Accessor accessor = new S3Accessor(gateway, URI.create("s3://bucket/path"), cfg());
+    S3Accessor accessor =
+        new S3Accessor(TestUtils.createTestFamily(gateway, URI.create("s3://bucket/path"), cfg()));
     fs =
         new S3FileSystem(accessor, direct.getContext()) {
           @Override


### PR DESCRIPTION
* Migrage io-s3, io-gcloud and io-bulkfs  api to be created via AttributeFamilyDescriptor
* Added setup method into `FileFormat`
* `org.apache.http.` needs to be shaded in io-s3
* Implement returning schema from `AlwaysFailSchemeParser`