### PR TITLE
[proxima-direct-core] Remove RetryableLogObserver public API

### DIFF
--- a/direct/core/src/test/java/cz/o2/proxima/direct/commitlog/CommitLogReaderTest.java
+++ b/direct/core/src/test/java/cz/o2/proxima/direct/commitlog/CommitLogReaderTest.java
@@ -169,8 +169,8 @@ public class CommitLogReaderTest {
     List<StreamElement> received = new ArrayList<>();
     CountDownLatch latch = new CountDownLatch(1);
     AtomicInteger count = new AtomicInteger();
-    final RetryableLogObserver observer =
-        RetryableLogObserver.of(
+    final LogObserver observer =
+        LogObservers.withNumRetriedExceptions(
             "test",
             2,
             new LogObserver() {

--- a/direct/core/src/test/java/cz/o2/proxima/direct/commitlog/RetryableLogObserverTest.java
+++ b/direct/core/src/test/java/cz/o2/proxima/direct/commitlog/RetryableLogObserverTest.java
@@ -15,19 +15,153 @@
  */
 package cz.o2.proxima.direct.commitlog;
 
+import cz.o2.proxima.direct.commitlog.LogObservers.TerminationStrategy;
+import cz.o2.proxima.functional.Consumer;
+import cz.o2.proxima.functional.UnaryFunction;
 import cz.o2.proxima.storage.StreamElement;
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class RetryableLogObserverTest {
 
   @Test
-  public void testRetryableError() {
+  public void testRetryableException() {
     final int numRetries = 10;
+    final AtomicReference<Throwable> exception = new AtomicReference<>();
     final RetryableLogObserver observer =
-        RetryableLogObserver.of(
+        new RetryableLogObserver(
             "test",
             numRetries,
+            withStrategy(exception::set, TerminationStrategy.RETHROW),
+            false,
+            new LogObserver() {
+
+              @Override
+              public boolean onError(Throwable error) {
+                // Retryable.
+                return true;
+              }
+
+              @Override
+              public boolean onNext(StreamElement ingest, OnNextContext context) {
+                return true;
+              }
+            });
+
+    try {
+      observer.onError(new OutOfMemoryError());
+      Assert.fail("Should have thrown exception");
+    } catch (OutOfMemoryError ex) {
+      Assert.assertEquals(ex, exception.get());
+    }
+
+    // Retry for max-number of times.
+    for (int i = 0; i < numRetries; i++) {
+      Assert.assertTrue(observer.onError(new Exception("Test.")));
+    }
+
+    // Out of retries.
+    try {
+      observer.onError(new Exception("Test."));
+      Assert.fail("Should have thrown exception");
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals(ex.getCause(), exception.get());
+    }
+
+    // Failure counter restarts after element is successfully processed.
+    observer.onNext(null, null);
+
+    // Retry for max-number of times.
+    for (int i = 0; i < numRetries; i++) {
+      Assert.assertTrue(observer.onError(new Exception("Test.")));
+    }
+
+    // Out of retries.
+    try {
+      observer.onError(new Exception("Test."));
+      Assert.fail("Should have thrown exception");
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals(ex.getCause(), exception.get());
+    }
+  }
+
+  @Test
+  public void testNonRetryableException() {
+    final int numRetries = 10;
+    final AtomicReference<Throwable> exception = new AtomicReference<>();
+    final RetryableLogObserver observer =
+        new RetryableLogObserver(
+            "test",
+            numRetries,
+            withStrategy(exception::set, TerminationStrategy.RETHROW),
+            false,
+            new LogObserver() {
+
+              @Override
+              public boolean onError(Throwable error) {
+                // Non-Retryable.
+                return false;
+              }
+
+              @Override
+              public boolean onNext(StreamElement ingest, OnNextContext context) {
+                throw new UnsupportedOperationException("Not implemented.");
+              }
+            });
+    try {
+      observer.onError(new OutOfMemoryError());
+      Assert.fail("Should have thrown exception");
+    } catch (OutOfMemoryError ex) {
+      Assert.assertEquals(ex, exception.get());
+    }
+    try {
+      observer.onError(new Exception("Test."));
+      Assert.fail("Should have thrown exception");
+    } catch (IllegalStateException ex) {
+      Assert.assertEquals(ex.getCause(), exception.get());
+    }
+  }
+
+  @Test
+  public void testNonRetryableExceptionWithStopProcessing() {
+    final int numRetries = 10;
+    final AtomicReference<Throwable> exception = new AtomicReference<>();
+    final RetryableLogObserver observer =
+        new RetryableLogObserver(
+            "test",
+            numRetries,
+            withStrategy(exception::set, TerminationStrategy.STOP_PROCESSING),
+            false,
+            new LogObserver() {
+
+              @Override
+              public boolean onError(Throwable error) {
+                // Non-Retryable.
+                return false;
+              }
+
+              @Override
+              public boolean onNext(StreamElement ingest, OnNextContext context) {
+                throw new UnsupportedOperationException("Not implemented.");
+              }
+            });
+
+    Assert.assertFalse(observer.onError(new OutOfMemoryError()));
+    Assert.assertFalse(observer.onError(new Exception("Test.")));
+  }
+
+  @Test
+  public void testRetryableError() {
+    final int numRetries = 10;
+    final AtomicReference<Throwable> exception = new AtomicReference<>();
+    final RetryableLogObserver observer =
+        new RetryableLogObserver(
+            "test",
+            numRetries,
+            withStrategy(exception::set, TerminationStrategy.RETHROW),
+            true,
             new LogObserver() {
 
               @Override
@@ -44,44 +178,112 @@ public class RetryableLogObserverTest {
 
     // Retry for max-number of times.
     for (int i = 0; i < numRetries; i++) {
-      Assert.assertTrue(observer.onError(new Exception("Test.")));
+      Assert.assertTrue(observer.onError(new OutOfMemoryError("Test.")));
     }
 
     // Out of retries.
-    Assert.assertFalse(observer.onError(new Exception("Test.")));
+    try {
+      observer.onError(new OutOfMemoryError("Test."));
+      Assert.fail("Should have thrown exception");
+    } catch (OutOfMemoryError ex) {
+      Assert.assertEquals(ex, exception.get());
+    }
 
     // Failure counter restarts after element is successfully processed.
     observer.onNext(null, null);
 
     // Retry for max-number of times.
     for (int i = 0; i < numRetries; i++) {
-      Assert.assertTrue(observer.onError(new Exception("Test.")));
+      Assert.assertTrue(observer.onError(new OutOfMemoryError("Test.")));
     }
 
     // Out of retries.
-    Assert.assertFalse(observer.onError(new Exception("Test.")));
+    try {
+      observer.onError(new OutOfMemoryError("Test."));
+      Assert.fail("Should have thrown exception");
+    } catch (OutOfMemoryError ex) {
+      Assert.assertEquals(ex, exception.get());
+    }
   }
 
   @Test
-  public void testNonRetryableError() {
+  public void testRetryableErrorWithStopProcessing() {
     final int numRetries = 10;
+    final AtomicReference<Throwable> exception = new AtomicReference<>();
     final RetryableLogObserver observer =
-        RetryableLogObserver.of(
+        new RetryableLogObserver(
             "test",
             numRetries,
+            withStrategy(exception::set, TerminationStrategy.STOP_PROCESSING),
+            true,
             new LogObserver() {
 
               @Override
               public boolean onError(Throwable error) {
-                // Non-Retryable.
-                return false;
+                // Retryable.
+                return true;
               }
 
               @Override
               public boolean onNext(StreamElement ingest, OnNextContext context) {
-                throw new UnsupportedOperationException("Not implemented.");
+                return true;
               }
             });
-    Assert.assertFalse(observer.onError(new Exception("Test.")));
+
+    // Retry for max-number of times.
+    for (int i = 0; i < numRetries; i++) {
+      Assert.assertTrue(observer.onError(new OutOfMemoryError("Test.")));
+    }
+
+    // Out of retries.
+    Assert.assertFalse(observer.onError(new OutOfMemoryError("Test.")));
+
+    // Failure counter restarts after element is successfully processed.
+    observer.onNext(null, null);
+
+    // Retry for max-number of times.
+    for (int i = 0; i < numRetries; i++) {
+      Assert.assertTrue(observer.onError(new OutOfMemoryError("Test.")));
+    }
+
+    // Out of retries.
+    Assert.assertFalse(observer.onError(new OutOfMemoryError("Test.")));
+  }
+
+  @Test
+  public void testHandleThrowableWithStrategy() {
+    try {
+      RetryableLogObserver.handleThrowableWithStrategy(
+          null, new OutOfMemoryError(), TerminationStrategy.RETHROW);
+      Assert.fail("Should have thrown exception");
+    } catch (OutOfMemoryError ex) {
+      // pass
+    }
+    try {
+      RetryableLogObserver.handleThrowableWithStrategy(
+          null, new IllegalArgumentException(), TerminationStrategy.RETHROW);
+      Assert.fail("Should have thrown exception");
+    } catch (IllegalArgumentException ex) {
+      // pass
+    }
+    try {
+      RetryableLogObserver.handleThrowableWithStrategy(
+          null, new IOException(), TerminationStrategy.RETHROW);
+      Assert.fail("Should have thrown exception");
+    } catch (IllegalStateException ex) {
+      Assert.assertTrue(ex.getCause() instanceof IOException);
+    }
+    Assert.assertFalse(
+        RetryableLogObserver.handleThrowableWithStrategy(
+            null, new OutOfMemoryError(), TerminationStrategy.STOP_PROCESSING));
+  }
+
+  private UnaryFunction<Throwable, TerminationStrategy> withStrategy(
+      Consumer<Throwable> consumer, TerminationStrategy strategy) {
+
+    return t -> {
+      consumer.accept(t);
+      return strategy;
+    };
   }
 }

--- a/direct/ingest-server/src/main/java/cz/o2/proxima/server/TransformationObserver.java
+++ b/direct/ingest-server/src/main/java/cz/o2/proxima/server/TransformationObserver.java
@@ -18,6 +18,7 @@ package cz.o2.proxima.server;
 import static cz.o2.proxima.server.IngestServer.ingestRequest;
 
 import cz.o2.proxima.direct.commitlog.LogObserver;
+import cz.o2.proxima.direct.commitlog.LogObservers.TerminationStrategy;
 import cz.o2.proxima.direct.core.DirectDataOperator;
 import cz.o2.proxima.repository.RepositoryFactory;
 import cz.o2.proxima.server.metrics.Metrics;
@@ -52,8 +53,12 @@ public class TransformationObserver implements LogObserver {
 
   @Override
   public boolean onError(Throwable error) {
+    return true;
+  }
+
+  public TerminationStrategy onFatalError(Throwable error) {
     Utils.die(String.format("Failed to transform using %s. Bailing out.", transformation));
-    return false;
+    return TerminationStrategy.RETHROW;
   }
 
   @Override

--- a/direct/io-kafka/src/test/java/cz/o2/proxima/direct/kafka/LocalKafkaCommitLogDescriptorTest.java
+++ b/direct/io-kafka/src/test/java/cz/o2/proxima/direct/kafka/LocalKafkaCommitLogDescriptorTest.java
@@ -25,9 +25,9 @@ import com.typesafe.config.ConfigFactory;
 import cz.o2.proxima.direct.commitlog.CommitLogReader;
 import cz.o2.proxima.direct.commitlog.LogObserver;
 import cz.o2.proxima.direct.commitlog.LogObserver.OnNextContext;
+import cz.o2.proxima.direct.commitlog.LogObservers;
 import cz.o2.proxima.direct.commitlog.ObserveHandle;
 import cz.o2.proxima.direct.commitlog.Offset;
-import cz.o2.proxima.direct.commitlog.RetryableLogObserver;
 import cz.o2.proxima.direct.core.Context;
 import cz.o2.proxima.direct.core.DirectDataOperator;
 import cz.o2.proxima.direct.core.OnlineAttributeWriter;
@@ -1491,8 +1491,8 @@ public class LocalKafkaCommitLogDescriptorTest implements Serializable {
 
     final int numRetries = 3;
     final CountDownLatch latch = new CountDownLatch(numRetries);
-    final RetryableLogObserver observer =
-        RetryableLogObserver.of(
+    final LogObserver observer =
+        LogObservers.withNumRetriedExceptions(
             "test",
             numRetries,
             new LogObserver() {


### PR DESCRIPTION
Introduce LogObserver.withNumRetried(Exceptions|Throwables).