### PR TITLE
[proxima-utils-zookeeper]: Do not try to load JettyAdminServer in tests

### DIFF
--- a/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
+++ b/utils-zookeeper/src/test/java/cz/o2/proxima/utils/zookeeper/ZKGlobalWatermarkTrackerTest.java
@@ -91,6 +91,7 @@ public class ZKGlobalWatermarkTrackerTest {
     Properties props = new Properties();
     props.setProperty("clientPort", String.valueOf(zkURI.getPort()));
     props.setProperty("dataDir", WORK_DIR.getAbsolutePath());
+    props.setProperty("admin.enableServer", String.valueOf(false));
     QuorumPeerConfig peerCfg = new QuorumPeerConfig();
     peerCfg.parseProperties(props);
     ServerConfig serverConfig = new ServerConfig();


### PR DESCRIPTION
We can disable admin server in Zookeeper started in tests as we are not
using it. Starting admin server just add some overhead and it sometimes
leads to flaky timeouts.

Also removed this ClassNotFoundException
```
java.lang.NoClassDefFoundError: org/eclipse/jetty/security/SecurityHandler
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:264)
        at org.apache.zookeeper.server.admin.AdminServerFactory.createAdminServer(AdminServerFactory.java:43)
        at org.apache.zookeeper.server.ZooKeeperServerMain.runFromConfig(ZooKeeperServerMain.java:151)
        at cz.o2.proxima.utils.zookeeper.ZKGlobalWatermarkTrackerTest.lambda$setupGlobal$0(ZKGlobalWatermarkTrackerTest.java:104)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ClassNotFoundException: org.eclipse.jetty.security.SecurityHandler
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:352)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
        ... 10 more
```