### PR TITLE
Return bigtable to jdk11 profile

### DIFF
--- a/direct/pom.xml
+++ b/direct/pom.xml
@@ -108,6 +108,7 @@
         <module>core-testing</module>
         <module>ingest-client</module>
         <module>ingest-server</module>
+        <module>io-bigtable</module>
         <module>io-blob</module>
         <module>io-bulkfs</module>
         <module>io-cassandra</module>


### PR DESCRIPTION
In current situation io-bigtable use jdk8 io-hbase which isn't build during CI run. This commit bring it back as https://github.com/datadrivencz/proxima-platform/pull/510 removes it.

We need to rebase this after  https://github.com/datadrivencz/proxima-platform/pull/510 is merged - Until that marked as WIP.