### PR TITLE
Fix cache usage in proto schema extraction to avoid Recursive update

### DIFF
--- a/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/utils/ProtoUtils.java
+++ b/scheme/proto/src/main/java/cz/o2/proxima/scheme/proto/utils/ProtoUtils.java
@@ -24,6 +24,7 @@ import cz.o2.proxima.scheme.SchemaDescriptors;
 import cz.o2.proxima.scheme.SchemaDescriptors.SchemaTypeDescriptor;
 import cz.o2.proxima.scheme.SchemaDescriptors.StructureTypeDescriptor;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 
@@ -43,10 +44,11 @@ public class ProtoUtils {
    */
   public static <T extends Message> StructureTypeDescriptor<T> convertProtoToSchema(
       Descriptor proto) {
-    return convertProtoMessage(proto);
+    return convertProtoMessage(proto, new ConcurrentHashMap<>());
   }
 
-  static <T extends Message> StructureTypeDescriptor<T> convertProtoMessage(Descriptor proto) {
+  static <T extends Message> StructureTypeDescriptor<T> convertProtoMessage(
+      Descriptor proto, Map<String, SchemaTypeDescriptor<?>> structCache) {
     final Map<String, SchemaTypeDescriptor<?>> fields =
         proto
             .getFields()
@@ -60,7 +62,7 @@ public class ProtoUtils {
                         throw new UnsupportedOperationException(
                             "Recursion in field [" + field.getName() + "] is not supported");
                       }
-                      return convertField(field);
+                      return convertField(field, structCache);
                     }));
 
     return SchemaDescriptors.structures(proto.getName(), fields);
@@ -74,7 +76,8 @@ public class ProtoUtils {
    * @return schema type descriptor
    */
   @SuppressWarnings("unchecked")
-  static <T> SchemaTypeDescriptor<T> convertField(FieldDescriptor proto) {
+  static <T> SchemaTypeDescriptor<T> convertField(
+      FieldDescriptor proto, Map<String, SchemaTypeDescriptor<?>> structCache) {
     SchemaTypeDescriptor<T> descriptor;
     switch (proto.getJavaType()) {
       case STRING:
@@ -110,8 +113,14 @@ public class ProtoUtils {
                         .collect(Collectors.toList()));
         break;
       case MESSAGE:
-        descriptor = (SchemaTypeDescriptor<T>) convertProtoMessage(proto.getMessageType());
-
+        final String messageTypeName = proto.getMessageType().toProto().getName();
+        if (!structCache.containsKey(messageTypeName)) {
+          descriptor =
+              (SchemaTypeDescriptor<T>) convertProtoMessage(proto.getMessageType(), structCache);
+          structCache.put(messageTypeName, descriptor);
+        } else {
+          descriptor = (SchemaTypeDescriptor<T>) structCache.get(messageTypeName);
+        }
         break;
       default:
         throw new IllegalStateException(

--- a/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/ProtoMessageValueAccessorTest.java
+++ b/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/ProtoMessageValueAccessorTest.java
@@ -17,18 +17,21 @@ package cz.o2.proxima.scheme.proto;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import com.google.protobuf.ByteString;
 import cz.o2.proxima.scheme.AttributeValueAccessors.StructureValue;
 import cz.o2.proxima.scheme.AttributeValueAccessors.StructureValueAccessor;
 import cz.o2.proxima.scheme.proto.test.Scheme.Event;
+import cz.o2.proxima.scheme.proto.test.Scheme.MultiLevelMessage;
 import cz.o2.proxima.scheme.proto.test.Scheme.RuleConfig;
 import cz.o2.proxima.scheme.proto.test.Scheme.Users;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage.Directions;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage.InnerMessage;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage.SecondInnerMessage;
+import cz.o2.proxima.scheme.proto.utils.ProtoUtils;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
@@ -40,6 +43,11 @@ import org.junit.Test;
 
 @Slf4j
 public class ProtoMessageValueAccessorTest {
+
+  @Test(timeout = 1000)
+  public void testInspectMultiLevelMessageNotHanged() {
+    assertNotNull(ProtoUtils.convertProtoToSchema(MultiLevelMessage.getDescriptor()));
+  }
 
   @Test
   public void testManipulateWithSimpleMessage() {

--- a/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/utils/ProtoUtilsTest.java
+++ b/scheme/proto/src/test/java/cz/o2/proxima/scheme/proto/utils/ProtoUtilsTest.java
@@ -20,6 +20,7 @@ import static org.junit.Assert.assertTrue;
 
 import cz.o2.proxima.scheme.AttributeValueType;
 import cz.o2.proxima.scheme.SchemaDescriptors.StructureTypeDescriptor;
+import cz.o2.proxima.scheme.proto.test.Scheme;
 import cz.o2.proxima.scheme.proto.test.Scheme.Device;
 import cz.o2.proxima.scheme.proto.test.Scheme.RecursiveMessage;
 import cz.o2.proxima.scheme.proto.test.Scheme.ValueSchemeMessage;
@@ -67,6 +68,13 @@ public class ProtoUtilsTest {
   public void testConvertMessageWithRecursion() {
     StructureTypeDescriptor<RecursiveMessage> descriptor =
         ProtoUtils.convertProtoToSchema(RecursiveMessage.getDescriptor());
+    log.debug("Schema: {}", descriptor);
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testConvertMessageWithTwoStepRecursion() {
+    StructureTypeDescriptor<RecursiveMessage> descriptor =
+        ProtoUtils.convertProtoToSchema(Scheme.TwoStepRecursiveMessage.getDescriptor());
     log.debug("Schema: {}", descriptor);
   }
 }

--- a/scheme/proto/src/test/proto/scheme.proto
+++ b/scheme/proto/src/test/proto/scheme.proto
@@ -80,6 +80,14 @@ message RecursiveMessage {
   RecursiveMessage recursion = 1;
 }
 
+message TwoStepRecursiveMessage {
+  message Inner {
+    TwoStepRecursiveMessage recursion = 1;
+  }
+  string name = 1;
+  Inner inner = 2;
+}
+
 message WithTimestamps {
   google.protobuf.Timestamp minTimestamp = 1;
   google.protobuf.Timestamp maxTimestamp = 2;

--- a/scheme/proto/src/test/proto/scheme.proto
+++ b/scheme/proto/src/test/proto/scheme.proto
@@ -17,6 +17,9 @@
 syntax = "proto3";
 option java_package = "cz.o2.proxima.scheme.proto.test";
 
+import "google/protobuf/timestamp.proto";
+import "readme.proto";
+
 message Event {
   string gatewayId = 1;
   bytes payload = 2;
@@ -75,4 +78,22 @@ message ValueSchemeMessage {
 
 message RecursiveMessage {
   RecursiveMessage recursion = 1;
+}
+
+message WithTimestamps {
+  google.protobuf.Timestamp minTimestamp = 1;
+  google.protobuf.Timestamp maxTimestamp = 2;
+}
+
+message MultiLevelMessage {
+  message Properties {
+    string id = 1;
+    google.protobuf.Timestamp minTimestamp = 2;
+    google.protobuf.Timestamp maxTimestamp = 3;
+    cz.o2.proxima.example.UserDetails user = 4;
+  }
+  string id = 1;
+  ValueSchemeMessage child = 2;
+  WithTimestamps timestamps = 3;
+  Properties props = 4;
 }


### PR DESCRIPTION
Fix exceptions like
```
java.lang.IllegalStateException: Recursive update
    at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1763)
    at cz.o2.proxima.scheme.proto.utils.ProtoUtils.convertField(ProtoUtils.java:117)
    at cz.o2.proxima.scheme.proto.utils.ProtoUtils.lambda$convertProtoMessage$0(ProtoUtils.java:65)
```