### PR TITLE
[io-kafka] keep source StreamElement#uuid in case of no seqId

### DIFF
--- a/direct/io-kafka/src/main/java/cz/o2/proxima/direct/io/kafka/KafkaAccessor.java
+++ b/direct/io-kafka/src/main/java/cz/o2/proxima/direct/io/kafka/KafkaAccessor.java
@@ -101,6 +101,9 @@ public class KafkaAccessor extends SerializableAbstractStorage implements DataAc
   /** A name for a header containing sequential ID of {@link StreamElement} (if any). */
   public static final String SEQUENCE_ID_HEADER = "seqId";
 
+  /** A name for a header containing UUID of {@link StreamElement} */
+  public static final String UUID_HEADER = "uuid";
+
   @Getter @Nullable private final String topic;
 
   @Getter @Nullable private final String topicPattern;

--- a/direct/io-kafka/src/test/java/cz/o2/proxima/direct/io/kafka/KafkaLogReaderIT.java
+++ b/direct/io-kafka/src/test/java/cz/o2/proxima/direct/io/kafka/KafkaLogReaderIT.java
@@ -123,9 +123,16 @@ public class KafkaLogReaderIT {
     }
 
     @Override
-    public boolean onNext(StreamElement ingest, OnNextContext context) {
-      if (!ingest.getKey().startsWith("poisoned-pill")) {
-        receivedElements.add(ingest);
+    public boolean onNext(StreamElement element, OnNextContext context) {
+      if (!element.getKey().startsWith("poisoned-pill")) {
+        if (!element.hasSequentialId()) {
+          try {
+            UUID uuid = UUID.fromString(element.getUuid());
+          } catch (IllegalArgumentException e) {
+            fail("Received UUID in wrong format. Received value: " + element.getUuid());
+          }
+        }
+        receivedElements.add(element);
       }
       context.confirm();
       watermarks.merge(context.getPartition(), context.getWatermark(), Math::max);


### PR DESCRIPTION
Store and restore origin StreamElement#uuid in case of no seqId so it can be stable between multiple storages.