### PR TITLE
[io-s3] Custom S3 endpoint need not be valid URI

### DIFF
--- a/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Client.java
+++ b/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Client.java
@@ -135,9 +135,9 @@ class S3Client implements Serializable {
       Preconditions.checkArgument(!secretKey.isEmpty(), "secret-key must not be empty");
       @Nullable String base64SseKey = getOpt(cfg, "ssec-base64-key", Object::toString, null);
       boolean sslEnabled = getOpt(cfg, "ssl-enabled", Boolean::parseBoolean, false);
-      @Nullable URI endpoint = getOpt(cfg, "endpoint", URI::create, null);
+      @Nullable String endpoint = getOpt(cfg, "endpoint", Object::toString, null);
       if (!sslEnabled && endpoint != null) {
-        sslEnabled = endpoint.getScheme().equalsIgnoreCase("https");
+        sslEnabled = endpoint.toLowerCase().startsWith("https://");
       }
 
       if (base64SseKey != null) {

--- a/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Client.java
+++ b/direct/io-s3/src/main/java/cz/o2/proxima/direct/s3/S3Client.java
@@ -135,9 +135,12 @@ class S3Client implements Serializable {
       Preconditions.checkArgument(!secretKey.isEmpty(), "secret-key must not be empty");
       @Nullable String base64SseKey = getOpt(cfg, "ssec-base64-key", Object::toString, null);
       boolean sslEnabled = getOpt(cfg, "ssl-enabled", Boolean::parseBoolean, false);
-      @Nullable String endpoint = getOpt(cfg, "endpoint", Object::toString, null);
+      @Nullable URI endpoint = getOpt(cfg, "endpoint", URI::create, null);
       if (!sslEnabled && endpoint != null) {
-        sslEnabled = endpoint.toLowerCase().startsWith("https://");
+        sslEnabled =
+            Optional.ofNullable(endpoint.getScheme())
+                .map(e -> e.equalsIgnoreCase("https"))
+                .orElse(false);
       }
 
       if (base64SseKey != null) {

--- a/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3ClientTest.java
+++ b/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3ClientTest.java
@@ -34,8 +34,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.Test;
 
+@Slf4j
 public class S3ClientTest {
 
   @Test
@@ -138,6 +140,7 @@ public class S3ClientTest {
     try {
       new S3Client(uri, options);
     } catch (Exception e) {
+      log.error("Unexpected exception.", e);
       fail("Unexpected exception " + e.getMessage());
     }
   }

--- a/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3ClientTest.java
+++ b/direct/io-s3/src/test/java/cz/o2/proxima/direct/s3/S3ClientTest.java
@@ -114,6 +114,26 @@ public class S3ClientTest {
     verifyCreateS3ClientNotThrowsException(uri, options);
   }
 
+  @Test
+  public void validateOptionsWithEndpointWithoutScheme() {
+    final URI uri = URI.create("s3://bucket/path");
+    Map<String, Object> options = new HashMap<>();
+    options.put("access-key", "access-key");
+    options.put("secret-key", "secret-key");
+    options.put("endpoint", "127.0.0.1");
+    verifyCreateS3ClientNotThrowsException(uri, options);
+    options.put("ssec-base64-key", "MzJieXRlc2xvbmdzZWNyZXRrZXltdXN0YmVnaXZlbjE=");
+    assertThrows(
+        "SSL is required when sse-c is enabled.",
+        IllegalArgumentException.class,
+        () -> new S3Client(uri, options));
+    options.put("ssl-enabled", "true");
+    verifyCreateS3ClientNotThrowsException(uri, options);
+    options.remove("ssl-enabled");
+    options.put("endpoint", "https://127.0.0.1");
+    verifyCreateS3ClientNotThrowsException(uri, options);
+  }
+
   private void verifyCreateS3ClientNotThrowsException(URI uri, Map<String, Object> options) {
     try {
       new S3Client(uri, options);


### PR DESCRIPTION
Fix situation when s3 endpoint is just hostname/ip without schema.