### PR TITLE
[io-kafka] Allow to specify ack and batch size for kafka producer

### DIFF
--- a/direct/io-kafka/src/main/java/cz/o2/proxima/direct/kafka/KafkaAccessor.java
+++ b/direct/io-kafka/src/main/java/cz/o2/proxima/direct/kafka/KafkaAccessor.java
@@ -50,7 +50,6 @@ import org.apache.kafka.clients.admin.Config;
 import org.apache.kafka.clients.admin.ConfigEntry;
 import org.apache.kafka.clients.admin.DescribeConfigsResult;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 
@@ -96,12 +95,6 @@ public class KafkaAccessor extends SerializableAbstractStorage implements DataAc
 
   /** A name for a header containing sequential ID of {@link StreamElement} (if any). */
   public static final String SEQUENCE_ID_HEADER = "seqId";
-
-  /** Default ack value for kafka producer */
-  public static final String DEFAULT_PRODUCER_ACK_SETTINGS = "all";
-
-  /** Default batch size for kafka producer */
-  public static final int DEFAULT_PRODUCER_BATCH_SIZE_SETTINGS = 16384;
 
   @Getter @Nullable private final String topic;
 
@@ -241,8 +234,6 @@ public class KafkaAccessor extends SerializableAbstractStorage implements DataAc
         props.put(e.getKey().substring(KAFKA_CONFIG_PREFIX.length()), e.getValue().toString());
       }
     }
-    props.putIfAbsent(ProducerConfig.ACKS_CONFIG, DEFAULT_PRODUCER_ACK_SETTINGS);
-    props.putIfAbsent(ProducerConfig.BATCH_SIZE_CONFIG, DEFAULT_PRODUCER_BATCH_SIZE_SETTINGS);
     return props;
   }
 

--- a/direct/io-kafka/src/test/java/cz/o2/proxima/direct/kafka/KafkaAccessorTest.java
+++ b/direct/io-kafka/src/test/java/cz/o2/proxima/direct/kafka/KafkaAccessorTest.java
@@ -168,11 +168,6 @@ public class KafkaAccessorTest implements Serializable {
             new HashMap<>());
     Properties props = kafkaAccessor.createProps();
     assertEquals("dummy", props.getProperty(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG));
-    assertEquals(
-        KafkaAccessor.DEFAULT_PRODUCER_ACK_SETTINGS, props.getProperty(ProducerConfig.ACKS_CONFIG));
-    assertEquals(
-        KafkaAccessor.DEFAULT_PRODUCER_BATCH_SIZE_SETTINGS,
-        props.get(ProducerConfig.BATCH_SIZE_CONFIG));
   }
 
   @Test


### PR DESCRIPTION
Not related:
     - Added check + test for state commitlog on regexp specified topics.
     - Added check for possible NPE in log for kafka write callback